### PR TITLE
Fixed: error notifications had the prefix twice

### DIFF
--- a/client/app/locales/en.coffee
+++ b/client/app/locales/en.coffee
@@ -41,7 +41,7 @@ module.exports =
     'home help step 1': "You must manually trigger the import, except if you enable the auto-import."
     'home help step 2': "Disable the auto-stop feature for the Konnector application in your Cozy, otherwise the auto-import won't work."
 
-    'notification import error': 'Konnector %{name}: an error occurred during import of data'
+    'notification import error': 'an error occurred during import of data'
 
     'error occurred during import.': 'An error occurred during the last import.'
     'error occurred during import:': 'An error occurred during the last import:'

--- a/client/app/locales/fr.coffee
+++ b/client/app/locales/fr.coffee
@@ -41,7 +41,7 @@ module.exports =
     'home help step 1': "Vous devez manuellement déclencher l'importation sauf si vous avez activé l'importation automatique"
     'home help step 2': "Désactivez la fonction d'auto-stop pour l'application Konnectors dans votre Cozy, sinon l'importation automatique ne fonctionnera pas."
 
-    'notification import error': "Konnector %{name} : une erreur est survenue pendant l'importation des données"
+    'notification import error': "une erreur est survenue pendant l'importation des données"
 
     'error occurred during import.': 'Une erreur est survenue lors de la dernière importation.'
     'error occurred during import:': 'Une erreur est survenue lors de la dernière importation :'


### PR DESCRIPTION
The output was "Konnector Free: Konnector Free: the notification content".