### PR TITLE
Added: specific icon's background color

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,6 @@
       "description": "This information is needed to localize the application in your language."
     }
   },
-  "cozy-displayName": "Konnectors"
+  "cozy-displayName": "Konnectors",
+  "cozy-color": "#e26987"
 }


### PR DESCRIPTION
By default it's the same as Calendar, which is annoying for ISEN users (they have 4 apps, 2 have the same background).