### PR TITLE
Save file name and file mime for clean link to bankoperation

### DIFF
--- a/server/lib/link_bank_operation.coffee
+++ b/server/lib/link_bank_operation.coffee
@@ -50,8 +50,8 @@ class BankOperationLinker
             amount = parseFloat entry.amount
         catch
             amount = 0
-
         for operation in operations
+        
             operationAmount = operation.amount
             if operationAmount < 0
                 operationAmount = operationAmount * -1
@@ -66,6 +66,11 @@ class BankOperationLinker
         else if operationToLink.binary is undefined
             @linkOperation operationToLink, entry, callback
         else if not operationToLink.binary.file?
+            @linkOperation operationToLink, entry, callback
+        #This allow to update information for already linked operation
+        else if not operationToLink.binary.fileName?
+            @linkOperation operationToLink, entry, callback
+        else if not operationToLink.binary.fileMime?
             @linkOperation operationToLink, entry, callback
         else
             callback()

--- a/server/models/bankoperation.coffee
+++ b/server/models/bankoperation.coffee
@@ -28,12 +28,15 @@ BankOperation::setBinaryFromFile = (fileId, callback) ->
             attributes =
                 binary:
                     file: file.binary.file
-
+                    fileName: file.name
+                    fileMime: file.mime
             @updateAttributes attributes, (err) =>
                 return callback err if err
 
                 @binary =
                     file: file.binary.file
+                    fileName: file.name
+                    fileMime: file.mime
                 callback()
 
         else


### PR DESCRIPTION
Fixes https://github.com/cozy-labs/konnectors/issues/52

This PR allows also to update already linked operations.

One question remains (just editorial) : 
do I rather use another name for fileName and fileMime ? (using only lower case field names)