### PR TITLE
Prevent starting a timer twice

### DIFF
--- a/server/lib/konnector_poller.coffee
+++ b/server/lib/konnector_poller.coffee
@@ -171,6 +171,7 @@ class KonnectorPoller
     # Start timeout for konnector
     startTimeout: (konnector, interval) ->
         nextImport = @checkImport.bind(@, konnector, interval)
+        clearTimeout @timeouts[konnector.slug] if @timeouts[konnector.slug]?
         @timeouts[konnector.slug] = setTimeout nextImport, interval
 
 


### PR DESCRIPTION
This is a backport of a fix that seems to work on ISEN branch.