### PR TITLE
Fix bug when commit have no parents

### DIFF
--- a/server/konnectors/githubcommits.coffee
+++ b/server/konnectors/githubcommits.coffee
@@ -153,7 +153,7 @@ logCommits = (requiredFields, entries, data, next) ->
                     data =
                         date: commit.commit.author.date
                         sha: commit.sha
-                        parent: commit.parents[0].sha
+                        parent: if commit.parents.length > 0 then commit.parents[0].sha else null
                         url: commit.url
                         author: commit.commit.author.name
                         email: commit.commit.author.email


### PR DESCRIPTION
```
TypeError: Cannot read property 'sha' of undefined
  at /usr/local/cozy/apps/konnectors/server/konnectors/githubcommits.coffee:158:50
  at parseBody (/usr/local/cozy/apps/konnectors/node_modules/request-json/main.js:35:12)
  at Request._callback (/usr/local/cozy/apps/konnectors/node_modules/request-json/main.js:77:18)
  at Request.self.callback (/usr/local/cozy/apps/konnectors/node_modules/request/request.js:121:22)
  at Request.emit (events.js:98:17)
  at Request.<anonymous> (/usr/local/cozy/apps/konnectors/node_modules/request/request.js:978:14)
  at Request.emit (events.js:117:20)
  at IncomingMessage.<anonymous> (/usr/local/cozy/apps/konnectors/node_modules/request/request.js:929:12)
  at IncomingMessage.emit (events.js:117:20)
  at _stream_readable.js:944:16
  at process._tickCallback (node.js:448:13)
```