### PR TITLE
Allow to have a more advanced naming for bills

### DIFF
--- a/server/lib/naming.coffee
+++ b/server/lib/naming.coffee
@@ -1,0 +1,55 @@
+
+# Simple library to build right names depending on parameters
+module.exports =
+
+
+    # Return a file name for a given and a given set of parameters (options).
+    # Use mainly for bill naming.
+    #
+    #
+    # Exemple of expected parameters and output:
+    #
+    # entry =
+    #     date: today
+    #     orderId: '123456'
+    #     travel: 'paris_lyon'
+    #
+    # options =
+    #     vendor: 'telecom'
+    #     dateFormat: 'YYYYMMDD'
+    #     extension: 'txt'
+    #     others: ['orderId', 'travel']
+    #
+    # naming.getEntryFileName  will return:
+    #
+    #     "YYYYMMDD_telecom_123456_paris_lyon.txt"
+    #
+    getEntryFileName: (entry, options) ->
+        name = ""
+
+        if typeof(options) is "string"
+            name = "#{entry.date.format 'YYYYMM'}_#{options}.pdf"
+
+        else
+
+            # Build date prefix.
+            if entry.date?
+                if options.dateFormat?
+                     name = entry.date.format options.dateFormat
+                else
+                     name = entry.date.format 'YYYYMM'
+
+            # Add vendor name.
+            name += "_#{options.vendor}"
+
+            # Add optional information.
+            if options.others?
+                for parameter in options.others
+                    name += "_#{entry[parameter]}" if entry[parameter]?
+
+            # Add extension.
+            extension = options.extension or 'pdf'
+            name = "#{name}.#{extension}"
+
+        return name
+

--- a/server/lib/save_data_and_file.coffee
+++ b/server/lib/save_data_and_file.coffee
@@ -1,7 +1,8 @@
 async = require 'async'
+naming = require './naming'
 File = require '../models/file'
 
-module.exports = (log, model, suffix, tags) ->
+module.exports = (log, model, options, tags) ->
     (requiredFields, entries, body, next) ->
         entries.filtered = entries.fetched unless entries.filtered?
 
@@ -9,7 +10,7 @@ module.exports = (log, model, suffix, tags) ->
             entryLabel = entry.date.format 'MMYYYY'
 
             createFileAndSaveData = (entry, entryLabel) ->
-                fileName = "#{entry.date.format 'YYYYMM'}_#{suffix}.pdf"
+                fileName = naming.getEntryFileName entry, options
                 date = entry.date
                 pdfurl = entry.pdfurl
                 path = requiredFields.folderPath
@@ -21,7 +22,7 @@ module.exports = (log, model, suffix, tags) ->
                     log.info "File for #{entryLabel} not created."
                     callback()
                 else
-                    log.info "File for #{entryLabel} created."
+                    log.info "File for #{entryLabel} created: #{fileName}"
                     entry.fileId = file.id
                     entry.binaryId = file.binary.file.id
                     saveEntry entry, entryLabel

--- a/tests/naming.coffee
+++ b/tests/naming.coffee
@@ -1,0 +1,64 @@
+should = require 'should'
+moment = require 'moment'
+log = require('printit')
+    prefix: 'test naming'
+
+naming = require '../server/lib/naming'
+
+today = moment()
+
+entry =
+    date: today
+    orderId: '123456'
+    travel: 'paris_lyon'
+
+
+describe '', ->
+
+    before ->
+
+    describe 'parameters is string', ->
+
+        it 'output should have a date', ->
+            todayPrefix = today.format 'YYYYMM'
+            name = naming.getEntryFileName entry, 'telecom'
+            name.should.equal "#{todayPrefix}_telecom.pdf"
+
+    describe 'parameters is an object', ->
+
+        it 'with parametered vendor', ->
+            todayPrefix = today.format 'YYYYMM'
+            name = naming.getEntryFileName entry,
+                vendor: 'telecom'
+            name.should.equal "#{todayPrefix}_telecom.pdf"
+
+        it 'with parametered date', ->
+            todayPrefix = today.format 'YYYYMMDD'
+            name = naming.getEntryFileName entry,
+                vendor: 'telecom'
+                dateFormat: 'YYYYMMDD'
+            name.should.equal "#{todayPrefix}_telecom.pdf"
+
+        it 'with extension parameters', ->
+            todayPrefix = today.format 'YYYYMM'
+            name = naming.getEntryFileName entry,
+                vendor: 'telecom'
+                extension: 'txt'
+            name.should.equal "#{todayPrefix}_telecom.txt"
+
+        it 'with other parameters', ->
+            todayPrefix = today.format 'YYYYMM'
+            name = naming.getEntryFileName entry,
+                vendor: 'telecom'
+                others: ['orderId', 'travel']
+            name.should.equal "#{todayPrefix}_telecom_123456_paris_lyon.pdf"
+
+        it 'with all parameters', ->
+            todayPrefix = today.format 'YYYYMMDD'
+            name = naming.getEntryFileName entry,
+                vendor: 'telecom'
+                dateFormat: 'YYYYMMDD'
+                extension: 'txt'
+                others: ['orderId', 'travel']
+            name.should.equal "#{todayPrefix}_telecom_123456_paris_lyon.txt"
+


### PR DESCRIPTION
Following the discussion of https://github.com/cozy-labs/konnectors/issues/85, I add the capability to parameterize file name for bills saved via a konnector as files.

@ZeHiro could you review it and tell me if it matches your expectation?