### PR TITLE
Import private github commits

### DIFF
--- a/build/server/konnectors/githubcommits.js
+++ b/build/server/konnectors/githubcommits.js
@@ -93,7 +93,7 @@ getEvents = function(requiredFields, commits, data, next) {
   username = requiredFields.login;
   pass = requiredFields.password;
   client.setBasicAuth(username, pass);
-  path = "users/" + username + "/events/public?page=";
+  path = "users/" + username + "/events?page=";
   data.commits = [];
   log.info("Fetch commits sha from events...");
   return async.eachSeries([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], function(page, callback) {

--- a/server/konnectors/githubcommits.coffee
+++ b/server/konnectors/githubcommits.coffee
@@ -83,7 +83,7 @@ getEvents = (requiredFields, commits, data, next) ->
 
     client.setBasicAuth username, pass
 
-    path = "users/#{username}/events/public?page="
+    path = "users/#{username}/events?page="
 
     data.commits = []
     log.info "Fetch commits sha from events..."


### PR DESCRIPTION
Currently, only public commits are imported. With this PR, private commits are also imported.