### PR TITLE
Fixed: use caldavuri to store ISEN's ID for events, because setting a predefined ID is forbidden in cozydb

### DIFF
--- a/server/konnectors/isen.coffee
+++ b/server/konnectors/isen.coffee
@@ -143,20 +143,20 @@ module.exports =
         if rawEvents.length is 0
           callback null, []
         else
-          async.reduce rawEvents, [], (memo, rawEvent, next) =>
-              # if there is an error, the event is not added to the memo
-              Event.createOrUpdate rawEvent, (err, event) =>
-                  if err?
-                      # creation errors shouldn't prevent the process to run
-                      # correctly because they are unlikely to happen,
-                      # and have a low criticity
-                      next null, memo
-                  else
-                      @checkEventsUpdateToNotify event, ->
-                          next null, memo.concat [event]
+            async.reduce rawEvents, [], (memo, rawEvent, next) =>
+                # if there is an error, the event is not added to the memo
+                Event.createOrUpdate rawEvent, (err, event) =>
+                    if err?
+                        # creation errors shouldn't prevent the process to run
+                        # correctly because they are unlikely to happen,
+                        # and have a low criticity
+                        next null, memo
+                    else
+                        @checkEventsUpdateToNotify event, ->
+                            next null, memo.concat [event]
 
-          , (err, events) ->
-              callback null, events
+            , (err, events) ->
+                callback null, events
 
 
     # Notifications should be created for events that have changed in the next
@@ -245,7 +245,9 @@ module.exports =
                         # it won't be deleted
                         now = moment()
                         inTheFuture = moment(event.start).isAfter now
-                        hasBeenCreatedByKonnector = /Aurion.*/.test event.id
+                        {caldavuri} = event
+                        hasBeenCreatedByKonnector = caldavuri? and \
+                                                   /Aurion.*/.test(caldavuri)
                         if event.id not in eventsReferenceId \
                         and event.tags[0] is DEFAULT_CALENDAR \
                         and hasBeenCreatedByKonnector \

--- a/server/models/event.coffee
+++ b/server/models/event.coffee
@@ -16,6 +16,7 @@ module.exports = Event = americano.getModel 'Event',
     alarms      : type: [Object]
     created     : type: String
     lastModification: type: String
+    caldavuri   : type: String
 
 require('cozy-ical').decorateEvent Event
 
@@ -26,13 +27,22 @@ Event.byCalendar = (calendarId, callback) ->
     Event.request 'byCalendar', key: calendarId, callback
 
 Event.createOrUpdate = (data, callback) ->
-    Event.request 'all', key: data.id, (err, events) ->
+    {id} = data
+    data.caldavuri = id
+    data.docType = "Event"
+    delete data._id
+    delete data._attachments
+    delete data._rev
+    delete data.binaries
+    delete data.id
+
+    Event.request 'bycaldavuri', key: id, (err, events) ->
         if err?
             log.error err
             Event.create data, callback
         else if events.length is 0
             Event.create data, callback
-        else if data.id is events[0].id
+        else if data.caldavuri is events[0].caldavuri
             log.debug 'Event already exists, updating...'
             event = events[0]
 

--- a/server/models/requests.coffee
+++ b/server/models/requests.coffee
@@ -26,3 +26,7 @@ module.exports =
 
     commit:
         byDate: americano.defaultRequests.by 'date'
+
+    event:
+        all: americano.defaultRequests.all
+        bycaldavuri: americano.defaultRequests.by 'caldavuri'


### PR DESCRIPTION
As a result, events where not created when imported from ISEN connector.