### PR TITLE
Fix exception when handling a server error

### DIFF
--- a/server/lib/importer.coffee
+++ b/server/lib/importer.coffee
@@ -24,7 +24,10 @@ module.exports = (konnector) ->
 
         konnector.import (err, notifContent) ->
 
-            if err and Object.keys(err).length > 0
+            # err can be an object or a string
+            if err? and
+               ((typeof(err) is 'object' and Object.keys(err).length > 0) or
+               typeof(err) is string)
                 log.error err
                 localizationKey = 'notification import error'
                 notifContent = localization.t localizationKey, name: model.name


### PR DESCRIPTION
Exception found in the logs of a user:

```
/usr/local/cozy/apps/konnectors/build/server/lib/importer.js:26
      if (err && Object.keys(err).length > 0) {
                        ^
TypeError: Object.keys called on non-object
    at Function.keys (native)
    at /usr/local/cozy/apps/konnectors/build/server/lib/importer.js:26:25
    at /usr/local/cozy/apps/konnectors/build/server/models/konnector.js:146:22
    at /usr/local/cozy/apps/konnectors/node_modules/cozydb/lib/model.js:34:14
    at /usr/local/cozy/apps/konnectors/node_modules/cozydb/lib/cozymodel.js:112:18
    at parseBody (/usr/local/cozy/apps/konnectors/node_modules/cozydb/node_modules/request-json-light/main.js:74:10)
    at IncomingMessage.<anonymous> (/usr/local/cozy/apps/konnectors/node_modules/cozydb/node_modules/request-json-light/main.js:99:14)
    at IncomingMessage.emit (events.js:117:20)
    at _stream_readable.js:944:16
    at process._tickCallback (node.js:448:13)
```