### PR TITLE
Add "use strict" to ES6 linkedin connector to avoid runtime error

### DIFF
--- a/server/konnectors/linkedin.js
+++ b/server/konnectors/linkedin.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const request = require('request');
 const https = require('https');
 const url = require('url');


### PR DESCRIPTION
Fix error

    SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:374:25)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at getKonnectorModules (/home/florian/Coding/NodeJS/cozy/konnectors/build/server/lib/konnector_hash.js:28:23)
    at Object.<anonymous> (/home/florian/Coding/NodeJS/cozy/konnectors/build/server/lib/konnector_hash.js:34:18)
    at Module._compile (module.js:410:26)