### PR TITLE
Fix build on node < 4

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "auto-reload-brunch": "> 1.0 < 1.5",
-    "brunch": "2.1.3",
+    "brunch": "^1.8.5",
     "clean-css-brunch": "> 1.0 < 1.5",
     "coffee-script-brunch": "> 1.0 < 1.5",
     "css-brunch": "> 1.0 < 1.5",


### PR DESCRIPTION
Brunch 2+ only works with Node 4+. 

I tried to downgrade brunch to version 1, everything seems OK regarding the build process.