### PR TITLE
Add OVH konnector

### DIFF
--- a/client/app/locales/en.coffee
+++ b/client/app/locales/en.coffee
@@ -77,6 +77,34 @@ module.exports =
     'konnector description numericable': "Download all your Numéricable Bills. This konnector requires the Files application to store the bill PDF files."
     'konnector description virginmobile': "Download all your Virgin Mobile  bills. This konnector requires the Files application to store the bill PDF files."
     'konnector description online_net': "Download all your Online.net bills. This konnector requires the Files application to store the bill PDF files."
+    'konnector description ovh_eu': """
+    Download all your OVH Europe bills. This konnector requires the Files application to store the bill PDF files.<br/>
+    At your first import, we will generate a link from which you will be able to enter your OVH Europe credentials.
+    """
+    'konnector description ovh_ca': """
+    Download all your OVH North-America bills. This konnector requires the Files application to store the bill PDF files.<br/>
+    At your first import, we will generate a link from which you will be able to enter your OVH North-America credentials.
+    """
+    'konnector description runabove': """
+    Download all your RunAbove bills. This konnector requires the Files application to store the bill PDF files.<br/>
+    At your first import, we will generate a link from which you will be able to enter your RunAbove credentials.
+    """
+    'konnector description kimsufi_eu': """
+    Download all your Kimsufi Europe bills. This konnector requires the Files application to store the bill PDF files.<br/>
+    At your first import, we will generate a link from which you will be able to enter your Kimsufi Europe credentials.
+    """
+    'konnector description kimsufi_ca': """
+    Download all your Kimsufi North-America bills. This konnector requires the Files application to store the bill PDF files.<br/>
+    At your first import, we will generate a link from which you will be able to enter your Kimsufi North-America credentials.
+    """
+    'konnector description soyoustart_eu': """
+    Download all your SoYouStart Europe bills. This konnector requires the Files application to store the bill PDF files.<br/>
+    At your first import, we will generate a link from which you will be able to enter your SoYouStart Europe credentials.
+    """
+    'konnector description soyoustart_ca': """
+    Download all your SoYouStart North-America bills. This konnector requires the Files application to store the bill PDF files.<br/>
+    At your first import, we will generate a link from which you will be able to enter your SoYouStart North-America credentials.
+    """
     'konnector description isen': "Students from ISEN engineer school can import their course materials and calendar."
     'konnector description ical_feed': "Download and import a remote Ical file (.ics)."
     'konnector description birthdays': "Create events in your calendar for each birhday of your contacts."
@@ -108,6 +136,13 @@ module.exports =
     'notification ical_feed creation': "%{smart_count} new event imported |||| %{smart_count} new events imported"
     'notification ical_feed update': "%{smart_count} new event updated |||| %{smart_count} new events updated"
     'notification birthdays creation': "%{smart_count} new birthday created |||| %{smart_count} new birthdays created"
+    'notification ovh_eu': "%{smart_count} new invoice imported |||| %{smart_count} new invoices imported"
+    'notification ovh_ca': "%{smart_count} new invoice imported |||| %{smart_count} new invoices imported"
+    'notification runabove': "%{smart_count} new invoice imported |||| %{smart_count} new invoices imported"
+    'notification kimsufi_eu': "%{smart_count} new invoice imported |||| %{smart_count} new invoices imported"
+    'notification kimsufi_ca': "%{smart_count} new invoice imported |||| %{smart_count} new invoices imported"
+    'notification soyoustart_eu': "%{smart_count} new invoice imported |||| %{smart_count} new invoices imported"
+    'notification soyoustart_ca': "%{smart_count} new invoice imported |||| %{smart_count} new invoices imported"
 
     "konnector birthdays birthday": "Birthday of"
 

--- a/client/app/locales/fr.coffee
+++ b/client/app/locales/fr.coffee
@@ -80,6 +80,34 @@ module.exports =
     'konnector description numericable': "Téléchargez toutes vos factures Numéricable. Pour pouvoir stocker les factures au format PDF, ce connecteur requiert que l'application Files soit installée sur votre Cozy."
     'konnector description virginmobile': "Téléchargez toutes vos factures Virgin Mobile. Pour pouvoir stocker les factures au format PDF, ce connecteur requiert que l'application Files soit installée sur votre Cozy."
     'konnector description online_net': "Téléchargez toutes vos factures Online.net. Pour pouvoir stocker les factures au format PDF, ce connecteur requiert que l'application Files soit installée sur votre Cozy."
+    'konnector description ovh_eu': """
+    Téléchargez toutes vos factures OVH Europe. Pour pouvoir stocker les factures au format PDF, ce connecteur requiert que l'application Files soit installée sur votre Cozy.<br/>
+    Lors de votre premier import nous générerons un lien à partir dulequel vous pourrez rentre vos identifiants OVH Europe.
+    """
+    'konnector description ovh_ca': """
+    Téléchargez toutes vos factures OVH North-America. Pour pouvoir stocker les factures au format PDF, ce connecteur requiert que l'application Files soit installée sur votre Cozy.<br/>
+    Lors de votre premier import nous générerons un lien à partir dulequel vous pourrez rentre vos identifiants OVH North-America.
+    """
+    'konnector description runabove': """
+    Téléchargez toutes vos factures RunAbove. Pour pouvoir stocker les factures au format PDF, ce connecteur requiert que l'application Files soit installée sur votre Cozy.<br/>
+    Lors de votre premier import nous générerons un lien à partir dulequel vous pourrez rentre vos identifiants RunAbove.
+    """
+    'konnector description kimsufi_eu': """
+    Téléchargez toutes vos factures Kimsufi Europe. Pour pouvoir stocker les factures au format PDF, ce connecteur requiert que l'application Files soit installée sur votre Cozy.<br/>
+    Lors de votre premier import nous générerons un lien à partir dulequel vous pourrez rentre vos identifiants Kimsufi Europe.
+    """
+    'konnector description kimsufi_ca': """
+    Téléchargez toutes vos factures Kimsufi North-America. Pour pouvoir stocker les factures au format PDF, ce connecteur requiert que l'application Files soit installée sur votre Cozy.<br/>
+    Lors de votre premier import nous générerons un lien à partir dulequel vous pourrez rentre vos identifiants Kimsufi North-America.
+    """
+    'konnector description soyoustart_eu': """
+    Téléchargez toutes vos factures SoYouStart Europe. Pour pouvoir stocker les factures au format PDF, ce connecteur requiert que l'application Files soit installée sur votre Cozy.<br/>
+    Lors de votre premier import nous générerons un lien à partir dulequel vous pourrez rentre vos identifiants SoYouStart Europe.
+    """
+    'konnector description soyoustart_ca': """
+    Téléchargez toutes vos factures SoYouStart North-America. Pour pouvoir stocker les factures au format PDF, ce connecteur requiert que l'application Files soit installée sur votre Cozy.<br/>
+    Lors de votre premier import nous générerons un lien à partir dulequel vous pourrez rentre vos identifiants SoYouStart North-America.
+    """
     'konnector description nest': "Enregistrez la température actuelle mesurée par votre Nest."
     'konnector description isen': "Les étudiants de l'école d'ingénieur ISEN peuvent importer leurs supports de cours et leur agenda."
     'konnector description googlecontacts': "Importez vos contacts Google dans votre Cozy via l'API de Google."
@@ -109,6 +137,13 @@ module.exports =
     'notification ical_feed creation': "%{smart_count} nouvel événement importé. |||| %{smart_count} nouveaux événements importés."
     'notification ical_feed update': "%{smart_count} événement mis à jour. |||| %{smart_count} événements mis à jour."
     'notification birthdays creation': "%{smart_count} nouvel anniversaire créé. |||| %{smart_count} nouveaux anniversaires créés."
+    'notification ovh_eu': "%{smart_count} nouvelle facture importée |||| %{smart_count} nouvelles factures importées"
+    'notification ovh_ca': "%{smart_count} nouvelle facture importée |||| %{smart_count} nouvelles factures importées"
+    'notification runabove': "%{smart_count} nouvelle facture importée |||| %{smart_count} nouvelles factures importées"
+    'notification kimsufi_eu': "%{smart_count} nouvelle facture importée |||| %{smart_count} nouvelles factures importées"
+    'notification kimsufi_ca': "%{smart_count} nouvelle facture importée |||| %{smart_count} nouvelles factures importées"
+    'notification soyoustart_eu': "%{smart_count} nouvelle facture importée |||| %{smart_count} nouvelles factures importées"
+    'notification soyoustart_ca': "%{smart_count} nouvelle facture importée |||| %{smart_count} nouvelles factures importées"
 
     "konnector danger zone": "Zone dangereuse"
     "konnector delete credentials": "Supprimer cette configuration."

--- a/client/app/views/konnector.coffee
+++ b/client/app/views/konnector.coffee
@@ -178,6 +178,15 @@ module.exports = class KonnectorView extends BaseView
     <b id="#{slug}-#{name}-input" >#{values[name]}</b>
 </div>
 """
+        else if val is 'link'
+            fieldHtml = """
+<div class="field line #{'hidden' if val is 'hidden'}">
+    <label for="#{slug}-#{name}-input">#{t(name)} : </label>
+    <a target="_blank" href="#{values[name]}" id="#{slug}-#{name}-input" >
+        #{values[name]}
+    </a>
+</div>
+"""
         else
             fieldHtml = """
 <div class="field line #{'hidden' if val is 'hidden'}">

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "moment": "2.10.6",
     "nest-api": "0.0.5",
     "node-polyglot": "0.4.1",
+    "ovh": "1.1.3",
     "pngjs-image": "0.11.6",
     "printit": "0.1.15",
     "querystring": "0.2.0",

--- a/server/konnectors/kimsufi_ca.coffee
+++ b/server/konnectors/kimsufi_ca.coffee
@@ -1,0 +1,11 @@
+baseOVHKonnector = require '../lib/base_ovh_konnector'
+
+name = 'Kimsufi CA'
+slug = 'kimsufi_ca'
+
+api =
+    endpoint: 'kimsufi-ca'
+    appKey: ''
+    appSecret: ''
+
+connector = module.exports = baseOVHKonnector.createNew(api, name, slug)

--- a/server/konnectors/kimsufi_eu.coffee
+++ b/server/konnectors/kimsufi_eu.coffee
@@ -1,0 +1,11 @@
+baseOVHKonnector = require '../lib/base_ovh_konnector'
+
+name = 'Kimsufi EU'
+slug = 'kimsufi_eu'
+
+api =
+    endpoint: 'kimsufi-eu'
+    appKey: ''
+    appSecret: ''
+
+connector = module.exports = baseOVHKonnector.createNew(api, name, slug)

--- a/server/konnectors/ovh_ca.coffee
+++ b/server/konnectors/ovh_ca.coffee
@@ -1,0 +1,11 @@
+baseOVHKonnector = require '../lib/base_ovh_konnector'
+
+name = 'OVH CA'
+slug = 'ovh_ca'
+
+api =
+    endpoint: 'ovh-ca'
+    appKey: ''
+    appSecret: ''
+
+connector = module.exports = baseOVHKonnector.createNew(api, name, slug)

--- a/server/konnectors/ovh_eu.coffee
+++ b/server/konnectors/ovh_eu.coffee
@@ -1,0 +1,11 @@
+baseOVHKonnector = require '../lib/base_ovh_konnector'
+
+name = 'OVH EU'
+slug = 'ovh_eu'
+
+api =
+    endpoint: 'ovh-eu'
+    appKey: 'zCqczKQV3Ka7ML2F'
+    appSecret: 'hVLSCmpmiLOQxrDCgzerKPly0RciWY7K'
+
+connector = module.exports = baseOVHKonnector.createNew(api, name, slug)

--- a/server/konnectors/runabove.coffee
+++ b/server/konnectors/runabove.coffee
@@ -1,0 +1,11 @@
+baseOVHKonnector = require '../lib/base_ovh_konnector'
+
+name = 'RunAbove CA'
+slug = 'runabove_ca'
+
+api =
+    endpoint: 'runabove-ca'
+    appKey: ''
+    appSecret: ''
+
+connector = module.exports = baseOVHKonnector.createNew(api, name, slug)

--- a/server/konnectors/soyoustart_ca.coffee
+++ b/server/konnectors/soyoustart_ca.coffee
@@ -1,0 +1,11 @@
+baseOVHKonnector = require '../lib/base_ovh_konnector'
+
+name = 'SoYouStart CA'
+slug = 'soyoustart_ca'
+
+api =
+    endpoint: 'soyoustart-ca'
+    appKey: ''
+    appSecret: ''
+
+connector = module.exports = baseOVHKonnector.createNew(api, name, slug)

--- a/server/konnectors/soyoustart_eu.coffee
+++ b/server/konnectors/soyoustart_eu.coffee
@@ -1,0 +1,11 @@
+baseOVHKonnector = require '../lib/base_ovh_konnector'
+
+name = 'SoYouStart EU'
+slug = 'soyoustart_eu'
+
+api =
+    endpoint: 'soyoustart-eu'
+    appKey: ''
+    appSecret: ''
+
+connector = module.exports = baseOVHKonnector.createNew(api, name, slug)

--- a/server/lib/base_ovh_konnector.coffee
+++ b/server/lib/base_ovh_konnector.coffee
@@ -1,0 +1,47 @@
+ovhFetcher = require '../lib/ovh_fetcher'
+filterExisting = require '../lib/filter_existing'
+saveDataAndFile = require '../lib/save_data_and_file'
+linkBankOperation = require '../lib/link_bank_operation'
+baseKonnector = require '../lib/base_konnector'
+
+Bill = require '../models/bill'
+
+module.exports =
+    createNew: (ovhApi, name, slug) ->
+
+        fileOptions =
+            vendor: slug
+            dateFormat: 'YYYYMMDD'
+
+        fakeLogger =
+            info: (text) -> connector?.logger.info(text)
+            error: (text) -> connector?.logger.error(text)
+            warn: (text) -> connector?.logger.warn(text)
+            debug: (text) -> connector?.logger.debug(text)
+
+        ovhFetcherInstance = ovhFetcher.new(ovhApi, slug, fakeLogger)
+
+        fetchBills = (requiredFields, entries, body, next) ->
+            ovhFetcherInstance.fetchBills(requiredFields, entries, body, next)
+
+        return connector = baseKonnector.createNew
+            name: name
+
+            fields:
+                loginUrl: "link"
+                token: "hidden"
+                folderPath: "folder"
+
+            models: [Bill],
+
+            fetchOperations: [
+              fetchBills,
+              filterExisting(fakeLogger, Bill)
+              saveDataAndFile(fakeLogger, Bill, fileOptions, ['bill']),
+              linkBankOperation
+                  log: fakeLogger
+                  model: Bill
+                  identifier: slug
+                  dateDelta: 4
+                  amountDelta: 0.1
+            ]

--- a/server/lib/ovh_fetcher.coffee
+++ b/server/lib/ovh_fetcher.coffee
@@ -1,0 +1,82 @@
+cozydb = require 'cozydb'
+
+moment = require 'moment'
+async = require 'async'
+fetcher = require '../lib/fetcher'
+
+class OVHFetcher
+    constructor: (ovhApi, slug, logger) ->
+        @ovh = require('ovh')(ovhApi)
+        @slug = slug
+        @logger = logger
+
+    fetchBills: (requiredFields, bills, data, next) =>
+        @ovh.consumerKey = requiredFields.token or null
+        return @needToConnectFirst(requiredFields, next) if not @ovh.consumerKey
+
+        @ovh.request 'GET', '/me/bill', (err, ovhBills) =>
+            if (err == 401 || err == 403)
+                return @needToConnectFirst(requiredFields, next)
+            else if (err)
+                return next(err)
+
+            # Fetch individually each bill and build an array.
+            async.map ovhBills, (ovhBill, cb) =>
+                @ovh.request('GET', '/me/bill/' + ovhBill, cb)
+            , (err, ovhBills) =>
+                return next err if err
+
+                bills.fetched = []
+
+                ovhBills.forEach (ovhBill) ->
+                    # Build bill object.
+                    bill =
+                        date: moment ovhBill.date
+                        amount: ovhBill.priceWithTax.value
+                        pdfurl: ovhBill.pdfUrl
+                        vendor: 'OVH'
+                        type: 'hosting'
+
+                    bills.fetched.push bill
+
+                @logger.info 'Bill data parsed.'
+                next()
+
+
+    getLoginUrl: (callback) ->
+        accessRules =
+          'accessRules': [
+            { 'method': 'GET', 'path': '/me/*' }
+          ]
+
+        @logger.info 'Request the login url...'
+        @ovh.request 'POST', '/auth/credential', accessRules
+        , (err, credential) ->
+            return callback err if err
+
+            callback(null, credential.validationUrl, credential.consumerKey)
+
+
+    saveUrlAndToken: (url, token, callback) =>
+        Konnector = require '../models/konnector'
+        Konnector.all (err, konnectors) =>
+            return callback err if err
+            konnector = konnectors.filter((k) => k.slug is @slug)[0]
+
+            konnector.fieldValues['loginUrl'] = url
+            konnector.fieldValues['token'] = token
+            konnector.save callback
+
+
+    needToConnectFirst: (requiredFields, callback) =>
+        @ovh.consumerKey = null
+        @getLoginUrl (err, url, token) =>
+            return callback err if err
+
+            requiredFields.loginUrl = url
+            requiredFields.token = token
+            @saveUrlAndToken url, token, ->
+                callback('You need to login to your OVH account first.')
+
+module.exports =
+    new: (ovhApi, slug, logger) -> new OVHFetcher(ovhApi, slug, logger)


### PR DESCRIPTION
Feel free to change appKey/appSecret, these are just for tests.

This konnector is only for ovh-eu but there are other available services:

 * OVH Europe: ovh-eu (actual)
 * OVH North-America: ovh-ca
 * RunAbove: runabove-ca
 * SoYouStart Europe: soyoustart-eu
 * SoYouStart North-America: soyoustart-ca
 * Kimsufi Europe: kimsufi-eu
 * Kimsufi North-America: kimsufi-ca

We choose the service when we generate the login url. So IMHO there are two options:
 * Allow the user to choose the service with a select box in a "OVH global konnector". The drawback is they won't be able to have multiple simultaneous services (ovh-eu and kimsufi-eu for example).
 * Create a "global ovh backend" and one konnector per service (so 7 konnectors). The drawback is duplication of code (boring code like translations etc)

I personnaly prefer the second option to keep the "1 konnector for 1 service" philosophy.

Thoughts?