### PR TITLE
Fix float format for ameli konnector

### DIFF
--- a/server/konnectors/ameli.coffee
+++ b/server/konnectors/ameli.coffee
@@ -92,7 +92,7 @@ parsePage = (requiredFields, healthBills, data, next) ->
         subtype = $($(this).find('td').get(1)).text()
 
         amount = $($(this).find('td').get(2)).text()
-        amount = amount.replace ' Euros', ''
+        amount = amount.replace(' euros', '').replace(',','.')
         amount = parseFloat amount
 
         # Get the details url


### PR DESCRIPTION
The comma value is not interpreted by the parseFloat function