### PR TITLE
Fix linting for JS files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,10 @@
   ],
 
   "rules": {
-    "no-param-reassign": [0, {"props": false}]
+    "no-param-reassign": [0, {"props": false}],
+    "strict": 0,
+    "no-shadow": 0,
+    "no-use-before-define": 0
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cozy-realtime-adapter": "1.0.0",
     "cozy-slug": "0.2.2",
     "cozydb": "0.1.10",
+    "eslint-plugin-react": "^4.2.3",
     "google-auth-library": "0.9.7",
     "imagemagick-stream": "2.0.0",
     "jade": "1.9.0",

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 ./node_modules/.bin/coffeelint -f coffeelint.json -r --color=always .
-./node_modules/.bin/eslint  server/konnectors/linkedin.js
+./node_modules/.bin/eslint  server/konnectors/*.js

--- a/server/konnectors/ameli.coffee
+++ b/server/konnectors/ameli.coffee
@@ -55,7 +55,9 @@ logIn = (requiredFields, billInfos, data, next) ->
             url: submitUrl
             headers:
                 'Cookie': res.headers['set-cookie']
-                'Referer': 'https://assure.ameli.fr/PortailAS/appmanager/PortailAS/assure?_nfpb=true&_pageLabel=as_login_page'
+                'Referer': 'https://assure.ameli.fr/PortailAS/appmanager/' + \
+                           'PortailAS/assure?_nfpb=true&_pageLabel=' + \
+                           'as_login_page'
 
         # Second request to authenticate
         request loginOptions, (err, res, body) ->
@@ -133,7 +135,7 @@ getPdf = (bill, callback) ->
             pdfUrl = "https://assure.ameli.fr"
             pdfUrl += html('.r_lien_pdf').attr('href')
             # Remove all the dirty escape characters...
-            pdfUrl = pdfUrl.replace(/(?:\r\n|\r|\n|\t)/g, '');
+            pdfUrl = pdfUrl.replace(/(?:\r\n|\r|\n|\t)/g, '')
             bill.pdfurl = pdfUrl
             callback null
 

--- a/server/konnectors/ical_feed.js
+++ b/server/konnectors/ical_feed.js
@@ -15,12 +15,12 @@ const Event = require('../models/event');
  * The goal of this connector is to fetch ICS file from an URL, parse it and
  * and store events in the Cozy
  */
-let connector = module.exports = baseKonnector.createNew({
+const connector = module.exports = baseKonnector.createNew({
   name: 'Ical Feed',
 
   fields: {
     url: 'text',
-    calendar: 'text'
+    calendar: 'text',
   },
 
   models: [Event],
@@ -30,19 +30,19 @@ let connector = module.exports = baseKonnector.createNew({
     parseFile,
     extractEvents,
     saveEvents,
-    buildNotifContent
-  ]
+    buildNotifContent,
+  ],
 
 });
 
 
 function downloadFile(requiredFields, entries, data, next) {
-  connector.logger.info("Downloading ICS file...");
+  connector.logger.info('Downloading ICS file...');
   request.get(requiredFields.url, (err, res, body) => {
     if (err) {
-      connector.logger.error("Download failed.");
+      connector.logger.error('Download failed.');
     } else {
-      connector.logger.info("Download succeeded.");
+      connector.logger.info('Download succeeded.');
       data.ical = body;
     }
     next(err);
@@ -52,27 +52,22 @@ function downloadFile(requiredFields, entries, data, next) {
 
 /* Parse file, based on timezone set at user level. */
 function parseFile(requiredFields, entries, data, next) {
-  connector.logger.info("Parsing ICS file...");
+  connector.logger.info('Parsing ICS file...');
   cozydb.api.getCozyUser((err, user) => {
-
-    if (err || user == null) {
-      connector.logger.error("Cannot retrieve Cozy user timezone.");
-      connector.logger.error("Parsing cannot be performed.");
+    if (err || user === null) {
+      connector.logger.error('Cannot retrieve Cozy user timezone.');
+      connector.logger.error('Parsing cannot be performed.');
       if (err === null) err = new Error('Cannot retrieve Cozy user timezone.');
       next(err);
-
     } else {
-      let parser = new ical.ICalParser();
-      let options = {defaultTimezone: user.timezone}
+      const parser = new ical.ICalParser();
+      const options = { defaultTimezone: user.timezone };
       parser.parseString(data.ical, options, (err, result) => {
-
         if (err) {
-          connector.logger.error("Parsing failed.");
-
+          connector.logger.error('Parsing failed.');
         } else {
           data.result = result;
         }
-
         next(err);
       });
     }
@@ -87,29 +82,28 @@ function extractEvents(requiredFields, entries, data, next) {
 
 
 function saveEvents(requiredFields, entries, data, next) {
-  connector.logger.info("Saving Events...");
+  connector.logger.info('Saving Events...');
   entries.nbCreations = 0;
   entries.nbUpdates = 0;
-
   async.eachSeries(entries.events, (icalEvent, done) => {
     icalEvent.tags = [requiredFields.calendar];
-    if(icalEvent.start.indexOf('T00:00:00+00:00') > 0 &&
+    if (icalEvent.start.indexOf('T00:00:00+00:00') > 0 &&
        icalEvent.end.indexOf('T00:00:00+00:00') > 0) {
-         icalEvent.start = icalEvent.start.substring(0, 10);
-         icalEvent.end = icalEvent.end.substring(0, 10);
+      icalEvent.start = icalEvent.start.substring(0, 10);
+      icalEvent.end = icalEvent.end.substring(0, 10);
     }
     Event.createOrUpdate(icalEvent, (err, cozyEvent, changes) => {
       if (err) {
         connector.logger.error(err);
-        connector.logger.error("Event cannot be saved.");
+        connector.logger.error('Event cannot be saved.');
       } else {
         if (changes.creation) entries.nbCreations++;
         if (changes.update) entries.nbUpdates++;
         done();
       }
     });
-  }, function(err) {
-    connector.logger.info("Events are saved.");
+  }, (err) => {
+    connector.logger.info('Events are saved.');
     next(err);
   });
 }
@@ -117,22 +111,22 @@ function saveEvents(requiredFields, entries, data, next) {
 
 function buildNotifContent(requiredFields, entries, data, next) {
   if (entries.nbCreations > 0) {
-    let localizationKey = 'notification ical_feed creation';
-    let options = {
+    const localizationKey = 'notification ical_feed creation';
+    const options = {
       smart_count: entries.nbCreations,
     };
     entries.notifContent = localization.t(localizationKey, options);
   }
   if (entries.nbUpdates > 0) {
-    let localizationKey = 'notification ical_feed update';
-    let options = {
-      smart_count: entries.nbUpdates
+    const localizationKey = 'notification ical_feed update';
+    const options = {
+      smart_count: entries.nbUpdates,
     };
-    if (entries.notifContent === undefined)
+    if (entries.notifContent === undefined) {
       entries.notifContent = localization.t(localizationKey, options);
-    else
+    } else {
       entries.notifContent += ' ' + localization.t(localizationKey, options);
+    }
   }
   next();
-};
-
+}


### PR DESCRIPTION
Eslint config changes:

* Do not complain about strict mode: it doesn't fit the Node 4 behavior.
* Do not complain when err is declared several times: it makes impossible to
  nest callbacks.
* Do not complain when functions are mentioned before being defined. It
  doesn't fit with the way we write connectors.

This commits changes the lint script too, in order to include all konnector
files. Finally, it comes with linting of JS files and missing linting of coffee
files.