### PR TITLE
Fix certificate issue

### DIFF
--- a/server/konnectors/ameli.coffee
+++ b/server/konnectors/ameli.coffee
@@ -42,6 +42,7 @@ logIn = (requiredFields, billInfos, data, next) ->
     options =
         method: 'GET'
         jar: true
+        strictSSL: false
         url: loginUrl
 
 
@@ -53,6 +54,7 @@ logIn = (requiredFields, billInfos, data, next) ->
             method: 'POST'
             form: form
             jar: true
+            strictSSL: false
             url: submitUrl
             headers:
                 'Cookie': res.headers['set-cookie']
@@ -72,6 +74,7 @@ logIn = (requiredFields, billInfos, data, next) ->
                 reimbursementOptions =
                     method: 'GET'
                     jar: true
+                    strictSSL: false
                     url: reimbursementUrl
 
                 # Last request to get the reimbursements
@@ -125,6 +128,7 @@ getPdf = (bill, callback) ->
     options =
         method: 'GET'
         jar: true
+        strictSSL: false
         url: detailsUrl
 
     # Request to get the pdf url


### PR DESCRIPTION
As mention on #216, the last debian version considers the Ameli's certificate issuer as untrusted.
This should be a temporary patch, waiting for the [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=812708) to be resolved on debian.