### PR TITLE
Try a smarter operation / bill match algorithm;

### DIFF
--- a/server/lib/link_bank_operation.coffee
+++ b/server/lib/link_bank_operation.coffee
@@ -16,9 +16,7 @@ class BankOperationLinker
         @log = options.log
         @model = options.model
         @identifier = options.identifier.toLowerCase()
-        @amountDelta = options.amountDelta or 0
-        @minAmountDelta = options.minAmountDelta or @amountDelta
-        @maxAmountDelta = options.maxAmountDelta or @amountDelta
+        @amountDelta = options.amountDelta or 0.001
         @dateDelta = options.dateDelta or 15
         @minDateDelta = options.minDateDelta or @dateDelta
         @maxDateDelta = options.maxDateDelta or @dateDelta
@@ -50,18 +48,22 @@ class BankOperationLinker
         operationToLink = null
 
         try
-            amount = parseFloat entry.amount
+            amount = Math.abs parseFloat entry.amount
         catch
-            amount = 0
+            callback()
+            return
 
+        minAmountDelta = Infinity
         for operation in operations
 
-            operationAmount = Math.abs operation.amount
+            opAmount = Math.abs operation.amount
+            amountDelta = Math.abs opAmount - amount
 
             if operation.title.toLowerCase().indexOf(@identifier) >= 0 and \
-            (amount - @minAmountDelta) <= operationAmount and \
-            (amount + @maxAmountDelta) >= operationAmount
+            amountDelta <= @amountDelta and \
+            amountDelta <= minAmountDelta
                 operationToLink = operation
+                minAmountDelta = amountDelta
 
         if not operationToLink?
             callback()


### PR DESCRIPTION
I was looking at #213 and thought about a simple situation where the match would lead to the first situation: if we match the right operation first, but then there happens to be another operation which matches the criterias too, we'll end up clobbering the right operation to link. So I think the linking should try to minimize the difference in amount, at least, which is what this PR does.

Also: I've removed `minAmountDelta` and `maxAmountDelta`, as nobody were using those in the konnectors directory. It also makes the comparisons simpler.

Also changed the default value of `amountDelta` to 0.001, because IEEE754 and comparing two floating point values for equality is equivalent to comparing the bits. If you're not convinced, run this piece of code: `if (0.1 + 0.2 !== 0.3) alert("LET THE WORLD BURN");`. :-)

Also, there was no clear reasons why we'd take the absolute value of the amount for the operation's amount but not for the reference amount; I've updated this for consistency.

Finally, I think that if we can't parse the amount, we'd better just skip the matching, as we'll end up either with an incorrect amount or a NaN.