### PR TITLE
Add a Facebook event konnector, which fetch user's event through FB OAuth2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Before opening any pull requests make sure that you follow these rules:
 * Twitter (published tweets)
 * Linkedin (contact information)
 * Google (contact information)
+* Facebook (event information)
 
 *Calendar*
 

--- a/client/app/locales/en.coffee
+++ b/client/app/locales/en.coffee
@@ -121,6 +121,7 @@ module.exports =
     'konnector customview googlecontacts 1': "1. Press \"connect your google account\" button to connect to your Google account and authorize your Cozy to access to it. Google will provide you with a complex string. Once you get it copy it in your clipboard, we will use it in second step."
     'konnector customview googlecontacts 2': "Connect your Google account"
     'konnector customview googlecontacts 3': "2. Paste this string in the Auth code field. Then press 'Import and save' button to start the sync. Account name will be automatically updated."
+    'konnector description facebook_events': "Import your Facebook's events in your Cozy. To setup, clic on Connect, then follow instructions, then copy the given code, and past it in the Access token field."
 
 
     # Konnectors' notifications
@@ -159,7 +160,7 @@ module.exports =
     'notification sfr_mobile': "%{smart_count} new invoice imported |||| %{smart_count} new invoices imported"
     'notification doctolib creation': "%{smart_count} new event imported |||| %{smart_count} new events imported"
     'notification doctolib update': "%{smart_count} event updated |||| %{smart_count} events updated"
-
+    'notification facebook_events': "%{smart_count] event updated |||| %{smart_count} events updated"
     "konnector birthdays birthday": "Birthday of"
 
     "konnector sncf reference": "Reference"

--- a/client/app/locales/en.coffee
+++ b/client/app/locales/en.coffee
@@ -160,7 +160,8 @@ module.exports =
     'notification sfr_mobile': "%{smart_count} new invoice imported |||| %{smart_count} new invoices imported"
     'notification doctolib creation': "%{smart_count} new event imported |||| %{smart_count} new events imported"
     'notification doctolib update': "%{smart_count} event updated |||| %{smart_count} events updated"
-    'notification facebook_events': "%{smart_count] event updated |||| %{smart_count} events updated"
+    'notification facebook_events creation': "%{smart_count] new event imported |||| %{smart_count} events updated"
+    'notification facebook_events updated': "%{smart_count] event updated |||| %{smart_count} events updated"
     "konnector birthdays birthday": "Birthday of"
 
     "konnector sncf reference": "Reference"

--- a/client/app/locales/fr.coffee
+++ b/client/app/locales/fr.coffee
@@ -160,7 +160,8 @@ module.exports =
     'notification sfr_mobile': "%{smart_count} nouvelle facture importée |||| %{smart_count} nouvelles factures importées"
     'notification doctolib creation': "%{smart_count} nouveau rendez-vous importé |||| %{smart_count} nouveaux rendez-vous importés"
     'notification doctolib update': "%{smart_count} rendez-vous mis à jour |||| %{smart_count} rendez-vous mis à jour"
-    'notification facebook_events': "%{smart_count} événement mis à jour. |||| %{smart_count} événements mis à jour."
+    'notification facebook_events creation': "%{smart_count} nouvel événement imporé. |||| %{smart_count} nouveaux événements importés."
+    'notification facebook_events update': "%{smart_count} événement mis à jour. |||| %{smart_count} événements mis à jour."
     "konnector birthdays birthday": "Anniversaire de"
 
     "konnector sncf reference": "Référence"

--- a/client/app/locales/fr.coffee
+++ b/client/app/locales/fr.coffee
@@ -124,6 +124,7 @@ module.exports =
     'konnector customview googlecontacts 1': "1. Cliquez sur le bouton \"Connecter votre compte google\" afin de connecter votre compte google et autoriser Cozy à y accéder. La fenêtre de Google va présenter une chaîne de caractère comlexe pour cela. Copiez la, elle sera utile à l'étape 2."
     'konnector customview googlecontacts 2': "Connecter votre compte Google"
     'konnector customview googlecontacts 3': "2. Copiez cette chaîne de caractères dans le champs Auth code. Puis cliquez sur le bouton \"Importer et sauvegarder \" pour lancer l'importation.  Le nom du compte sera mis à jour automatiquement."
+    'konnector description facebook_events': "Importez vos événements Facebook dans votre Cozy. Pour ce faire, cliquez sur le bouton Connect, suivez les instructions, puis copier le code, puis revenez sur cette page pour le coller dans le champs Access token."
 
     # Konnectors' notifications
     'notification prefix': "Konnector %{name} :"
@@ -159,6 +160,7 @@ module.exports =
     'notification sfr_mobile': "%{smart_count} nouvelle facture importée |||| %{smart_count} nouvelles factures importées"
     'notification doctolib creation': "%{smart_count} nouveau rendez-vous importé |||| %{smart_count} nouveaux rendez-vous importés"
     'notification doctolib update': "%{smart_count} rendez-vous mis à jour |||| %{smart_count} rendez-vous mis à jour"
+    'notification facebook_events': "%{smart_count} événement mis à jour. |||| %{smart_count} événements mis à jour."
     "konnector birthdays birthday": "Anniversaire de"
 
     "konnector sncf reference": "Référence"

--- a/server/konnectors/facebook_events.js
+++ b/server/konnectors/facebook_events.js
@@ -1,0 +1,231 @@
+'use strict';
+
+const async = require('async');
+const request = require('request');
+const cozydb = require('cozydb');
+const moment = require('moment');
+
+const baseKonnector = require('../lib/base_konnector');
+const localization = require('../lib/localization_manager');
+
+const Event = require('../models/event');
+
+const API_ROOT = 'https://graph.facebook.com/v2.5/';
+
+const appId = '181683981887939' ;
+const appSecret = 'eb1a6431ec6f4adc5ac9ec4dc98d3962';
+
+const scope = 'user_events' ;
+
+
+/*
+ * The goal of this connector is to fetch event from facebook and store them
+ * in the Cozy
+ */
+const connector = module.exports = baseKonnector.createNew({
+  name: 'Facebook Events',
+  slug: 'facebook_events',
+  customView: '<p>To konnect your Facebook account, click here:</p>' +
+    '<a href=' + getOAuthProxyUrl() + ' target="_blank" >Facebook Login</a>',
+
+  fields: {
+    accessToken: 'text',
+  },
+
+  models: [Event],
+
+  fetchOperations: [
+    updateToken,
+    saveTokenInKonnector,
+    downloadData,
+    parseData,
+    saveEvents,
+    buildNotifContent,
+  ],
+
+});
+
+function getOAuthProxyUrl() {
+  var baseUri = 'https://jacquarg.github.io/proxy_redirect/facebook_events/';
+  var params = 'appId=' + appId + '&scope=' + scope;
+  params += '&redirect=display'
+  return  baseUri + '?' + params ;
+}
+
+
+function updateToken(requiredFields, entries, data, next) {
+  connector.logger.info('Update facebook token');
+
+  request.get(API_ROOT + 'oauth/access_token?' +
+    'grant_type=fb_exchange_token&client_id=' + appId +
+    '&client_secret=' + appSecret +
+    '&fb_exchange_token=' + requiredFields.accessToken,
+    (err, res, body) => {
+      if (err) {
+        connector.logger.error('Update token failed: ' + err.msg);
+        // TODO : notification "reconnect"
+      } else {
+        data.accessToken = JSON.parse(body).access_token ;
+      }
+      next(err);
+  });
+
+}
+
+// Save konnector's fieldValues during fetch process.
+function saveTokenInKonnector(requiredFields, entries, data, callback) {
+  connector.logger.info('Save refreshed token.');
+
+  var Konnector = require('../models/konnector');
+    // TODO: should work:
+    // Konnector.get(connector.slug, function(err, konnector) {
+  Konnector.all((err, konnectors) => {
+    if (err) {
+      connector.logger.error("Can't fetch konnector instances", + err.msg);
+      return callback(err);
+    }
+
+    try {
+      var konnector = konnectors.filter(function(k) {
+          return k.slug === connector.slug;
+      })[0];
+
+      // Find which account we are using now.
+      var currentAccount = konnector.accounts.filter(function(account) {
+        return account.accessToken === requiredFields.accessToken;
+      })[0];
+
+      currentAccount.accessToken = data.accessToken;
+
+    } catch (e) {
+      connector.logger.error("Can't fetch konnector instances");
+      return callback(e);
+    }
+
+    konnector.updateAttributes({ accounts: konnector.accounts }, callback);
+  });
+}
+
+
+function downloadData(requiredFields, entries, data, next) {
+  connector.logger.info('Downloading events data from Facebook...');
+  request.get(API_ROOT + 'me/events?access_token='+ requiredFields.accessToken,
+    (err, res, body) => {
+
+    if (err) {
+      connector.logger.error('Download failed: ' + err.msg);
+    } else {
+      connector.logger.info('Download succeeded.');
+      // We don't handle pagination here, thinking that, with polling, usefull // events will fit in the first page.
+      try {
+        data.raw = JSON.parse(body).data;
+      } catch (e) {
+        connector.logger.error("Can't parse fetched data.");
+        err = e;
+      }
+    }
+    next(err);
+  });
+}
+
+
+/* Parse file, based on timezone set at user level. */
+function parseData(requiredFields, entries, data, next) {
+  connector.logger.info('Parsing raw Events Data...');
+
+  var list = data.raw.map((fbEvent) => {
+    try {
+      if (fbEvent.rsvp_status !== "attending") {
+        return null;
+      }
+
+      var date = new Date(fbEvent.start_time);
+
+      var locationStr = '';
+      if (fbEvent.place) {
+          locationStr = fbEvent.place.name;
+          if (fbEvent.place.location) {
+            locationStr += ', ' + fbEvent.place.location.street + ', ';
+            locationStr += fbEvent.place.location.city;
+            locationStr += ' ' + fbEvent.place.location.zip;
+            locationStr += ' (' + fbEvent.place.location.latitude;
+            locationStr += ', ' + fbEvent.place.location.longitude + ')';
+          }
+      }
+
+      return {
+        start: date.toISOString(),
+        end: moment(date).add(2, 'hours').toISOString(), // TODO create an end time !
+        place: locationStr,
+        details: fbEvent.description,
+        description: fbEvent.name,
+        tags: ['Facebook Events'],
+        // attendees: []
+        // created:
+        id: "" + fbEvent.id,
+        // caldavuri: "" + fbEvent.id, // actualy used elsewhere as external id.
+        // uuid
+        lastModification: new Date().toISOString(),
+
+        accounts: {
+          "type": "com.facebook",
+          "name": "me",
+          "id": "" + fbEvent.id,
+          "lastUpdate": new Date().toISOString() }
+      };
+
+    } catch(e) {
+      connector.logger.error('Skip an event while parsing it.', e);
+      return null;
+    }
+  });
+
+  entries.events = list.filter((ev) => { return ev !== null });
+
+  next();
+}
+
+
+function saveEvents(requiredFields, entries, data, next) {
+  connector.logger.info('Saving Events...');
+  entries.nbCreations = 0;
+  entries.nbUpdates = 0;
+  async.eachSeries(entries.events, (fbEvent, done) => {
+    Event.createOrUpdate(fbEvent, (err, cozyEvent, changes) => {
+      if (err) {
+        connector.logger.error(err);
+        connector.logger.error('Event cannot be saved.');
+      } else {
+        if (changes.creation) entries.nbCreations++;
+        if (changes.update) entries.nbUpdates++;
+        done();
+      }
+    });
+  }, (err) => {
+    connector.logger.info('Events are saved.');
+    next(err);
+  });
+}
+
+
+function buildNotifContent(requiredFields, entries, data, next) {
+  if (entries.nbCreations > 0) {
+    const localizationKey = 'notification facebook_events creation';
+    const options = {
+      smart_count: entries.nbCreations,
+    };
+    entries.notifContent = localization.t(localizationKey, options);
+  }
+  if (entries.nbUpdates > 0) {
+    const localizationKey = 'notification facebook_events update';
+    const options = {
+      smart_count: entries.nbUpdates,
+    };
+    if (entries.notifContent === undefined) {
+      entries.notifContent = localization.t(localizationKey, options);
+    } else {
+      entries.notifContent += ` ${localization.t(localizationKey, options)}`;
+    }
+  }
+  next();
+}

--- a/server/konnectors/facebook_events.js
+++ b/server/konnectors/facebook_events.js
@@ -94,14 +94,11 @@ function saveTokenInKonnector(requiredFields, entries, data, callback) {
     }
     let konnector = null;
     try {
-      konnector = konnectors.filter((k) => {
-        return k.slug === connector.slug;
-      })[0];
+      konnector = konnectors.filter(k => k.slug === connector.slug)[0];
 
       // Find which account we are using now.
-      const currentAccount = konnector.accounts.filter((account) => {
-        return account.accessToken === requiredFields.accessToken;
-      })[0];
+      const currentAccount = konnector.accounts.filter(account =>
+        account.accessToken === requiredFields.accessToken)[0];
 
       currentAccount.accessToken = data.accessToken;
     } catch (e) {
@@ -191,7 +188,7 @@ function parseData(requiredFields, entries, data, next) {
     }
   });
 
-  entries.events = list.filter(ev => { return ev !== null; });
+  entries.events = list.filter(ev => ev !== null; );
 
   next();
 }


### PR DESCRIPTION
A Konnector which add "accepted" Facebook event to a Calendar in the Cozy.
This Konnector is mainly a proof of concept of using OAuth2 API with a Cozy (which  should open the door to about all modern APIs), in a confident way. Here, the Konnector use a _redirect_uri proxy_ which is a simple page, hosted on github.io : https://github.com/jacquarg/jacquarg.github.io/blob/master/proxy_redirect/facebook_events/index.html

Actually, the Konnector requires to Copy/Past the token ; but everything is setup for automatic handling (with redirections, ...) - it's not done yet because Konnector UI don't provide easy access to the UI and routes.

