### PR TITLE
Konnector for captain train 

### DIFF
--- a/client/app/locales/en.coffee
+++ b/client/app/locales/en.coffee
@@ -122,6 +122,7 @@ module.exports =
     'konnector customview googlecontacts 2': "Connect your Google account"
     'konnector customview googlecontacts 3': "2. Paste this string in the Auth code field. Then press 'Import and save' button to start the sync. Account name will be automatically updated."
     'konnector description directenergie': "Downloads all your bills from the French energy provider Direct Energie."
+    'konnector description captain_train' : 'Downloads all your bills from the train ticket reseller Captain Train. This connector only uses normal authentification (email/password) and no Facebook/Google login. This konnector does not provides events for your calendar. For this visit, your Captain Train account (<a href="https://www.captaintrain.com/preferences/calendars">here</a>) and use the provided Ical feed link with the Ical Feed connector(<a href="#konnector/ical_feed">here<a>).'
 
     # Konnectors' notifications
     'notification prefix': "Konnector %{name}:"
@@ -160,6 +161,7 @@ module.exports =
     'notification doctolib creation': "%{smart_count} new event imported |||| %{smart_count} new events imported"
     'notification doctolib update': "%{smart_count} event updated |||| %{smart_count} events updated"
     'notification direct energie': "%{smart_count} new invoice imported |||| %{smart_count} new invoices imported"
+    'notification captain_train': "%{smart_count} new invoice imported |||| %{smart_count} new bills imported"
 
     "konnector birthdays birthday": "Birthday of"
 

--- a/client/app/locales/fr.coffee
+++ b/client/app/locales/fr.coffee
@@ -125,7 +125,7 @@ module.exports =
     'konnector customview googlecontacts 2': "Connecter votre compte Google"
     'konnector customview googlecontacts 3': "2. Copiez cette chaîne de caractères dans le champs Auth code. Puis cliquez sur le bouton \"Importer et sauvegarder \" pour lancer l'importation.  Le nom du compte sera mis à jour automatiquement."
     'konnector description directenergie': "Télécharge toutes vos factures pour votre compte actif depuis le site de Direct Energie."
-
+    'konnector description captain_train' : "Télécharge toutes les factures du vendeur de billet de train Captain Train. Ce connector ne supporte qu'une autentification normale (email/mot de passe), et ne permet pas la connection avec les comptes Facebook ou Google. Ce connector ne fournit pas non plus d'évenements pour votre agenda. Pour ceci, activez l'option sur votre compte capitaine train (<a href=\"https://www.captaintrain.com/preferences/calendars\">ici</a>) et utilisez le lien du flux Ical fourni avec le connector Ical feed (<a href=\"#konnector/ical_feed\">ici<a>)."
     # Konnectors' notifications
     'notification prefix': "Konnector %{name} :"
     'notification github commits': "%{smart_count} nouveau commit importé |||| %{smart_count} nouveaux commits importés"
@@ -161,6 +161,7 @@ module.exports =
     'notification doctolib creation': "%{smart_count} nouveau rendez-vous importé |||| %{smart_count} nouveaux rendez-vous importés"
     'notification doctolib update': "%{smart_count} rendez-vous mis à jour |||| %{smart_count} rendez-vous mis à jour"
     'notification direct energie': "%{smart_count} nouvelle facture importée |||| %{smart_count} nouvelles factures importées"
+    'notification captain_train': "%{smart_count} nouvelle facture importée |||| %{smart_count} nouvelles factures importées"
 
     "konnector birthdays birthday": "Anniversaire de"
 

--- a/server/konnectors/captain_train.js
+++ b/server/konnectors/captain_train.js
@@ -1,0 +1,330 @@
+'use strict';
+
+const baseKonnector = require('../lib/base_konnector');
+const filterExisting = require('../lib/filter_existing');
+const localization = require('../lib/localization_manager');
+const saveDataAndFile = require('../lib/save_data_and_file');
+const linkBankOperation = require('../lib/link_bank_operation');
+const requestJson = require('request-json');
+const request = require('request');
+const cheerio = require('cheerio');
+const moment = require('moment');
+
+const Bill = require('../models/bill');
+/* The goal of this connector is to fetch bills from the
+service captaintrain.com */
+
+const logger = require('printit')({
+  prefix: 'Captaintrain',
+  date: true,
+});
+
+
+module.exports = baseKonnector.createNew({
+  name: 'Captain Train',
+
+  fields: {
+    login: 'email',
+    password: 'password',
+    folderPath: 'folder',
+  },
+
+  models: [Bill],
+
+  fetchOperations: [
+    login,
+    fetchBills,
+    customFilterExisting,
+    customSaveDataAndFile,
+    linkBankOperation({
+      log: logger,
+      minDateDelta: 1,
+      maxDateDelta: 1,
+      model: Bill,
+      amountDelta: 0.1,
+      identifier: ['CAPITAINE TRAIN', 'CAPTAIN TRAIN', 'OUIGO'],
+    }),
+    buildNotifContent,
+  ],
+
+});
+
+const fileOptions = {
+  vendor: 'Captaintrain',
+  dateFormat: 'YYYYMMDD',
+};
+
+const baseUrl = 'https://www.captaintrain.com/';
+const client = requestJson.createClient(baseUrl);
+const userAgent = 'Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:37.0) Gecko/20100101 Firefox/37.0';
+// Authenticity token used by the jequest-json client.
+let csrfToken;
+client.headers['user-agent'] = userAgent;
+function login(requiredFields, entries, data, next) {
+  const options = {
+    method: 'GET',
+    url: `${baseUrl}signin`,
+    headers: {
+      'User-Agent': userAgent,
+      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    },
+    jar: true,
+  };
+  request(options, (err, res, body) => {
+    if (err) {
+      logger.error(err);
+      next(err);
+    }
+    // Retrieve the authenticity token
+    const $ = cheerio.load(body);
+    csrfToken = $('meta[name=csrf-token]').attr('content');
+    // Retrieve the cookie for the request-json clien
+    let cookie = res.headers['set-cookie'][0];
+    // Signin form
+    const signinForm = {
+      concur_auth_code: null,
+      concur_migration_type: null,
+      concur_new_email: null,
+      correlation_key: null,
+      email: requiredFields.login,
+      facebook_id: null,
+      facebook_token: null,
+      google_code: null,
+      google_id: null,
+      password: requiredFields.password,
+      source: null,
+      user_itokend: null,
+    };
+    client.headers.cookie = cookie;
+    // Signin
+    client.post(`${baseUrl}api/v5/account/signin`, signinForm, (err, res, body) => {
+      if (err) {
+        logger.error(err);
+        next(err);
+      }
+
+      if (res.statusCode === 422) {
+        next('bad credentials');
+      }
+
+      // Retrieve token for json client
+      const token = body.meta.token;
+
+     // Login data for the json client
+      const loginData = {
+        email: requiredFields.login,
+        password: requiredFields.password,
+        authenticity_token: csrfToken,
+      };
+      options.method = 'POST';
+      options.url = `${baseUrl}login`;
+      options.form = loginData;
+      // Log in
+      request(options, (err, res) => {
+        // Update cookie
+        cookie = res.headers['set-cookie'][0];
+        if (err) {
+          next(err);
+        }
+
+        client.headers.cookie = cookie;
+        client.headers.Authorization = `Token token="${token}"`;
+        data.authHeader = `Token token="${token}"`;
+        // the api/v5/pnrs uri gives all information necessary to get bill information
+        client.get(`${baseUrl}api/v5/pnrs`, (err, res, body) => {
+          if (err) {
+            logger.error(err);
+            next(err);
+          }
+          // We check their are bills
+          if (body.proofs && body.proofs.length > 0) {
+            saveMetadata(data, body);
+            getNextMetaData(computeNextDate(body.pnrs), data, next);
+          } else {
+            next();
+          }
+        });
+      });
+    });
+  });
+}
+
+function computeNextDate(pnrs) {
+  // To get new bills, it is necessary to get api/v5/pnrs?date=YYYY-MM-DD
+  // This function computes the date YYYY-MM-DD
+  // YYYY-MM-DD :
+  //    - DD: always 1
+  //    - MM: month before the month of the youngest received pnr
+  //    - YY: year of the first month before the youngest received pnr
+
+  // Indentify the minimum date in the pnr list
+  const minDate = pnrs.reduce((min, pnr) => Math.min(+min, +new Date(pnr.sort_date)), Infinity);
+  return moment(minDate).subtract(1, 'month').set('date', 1)
+                        .format('YYYY-MM-DD');
+}
+
+
+function getNextMetaData(startdate, data, callback) {
+  client.get(`${baseUrl}api/v5/pnrs?date=${startdate}`, (err, res, body) => {
+    if (err) {
+      logger.error(err);
+      callback(err);
+    }
+    if (body.proofs && body.proofs.length > 0) {
+      saveMetadata(data, body);
+      getNextMetaData(computeNextDate(body.pnrs), data, callback);
+    } else {
+      callback();
+    }
+  });
+}
+
+function saveMetadata(data, body) {
+  // Body structure received for api/v5/pnrs (with or without date parameter)
+  //
+  // body.pnrs (table of pnr):
+  //  - id: unique identifier
+  //  - sort_date: creation date
+  //  - system: payment system, defines the label of operation. Default is sncf.
+  //  - after_sales_log_ids: list of ids of related refunds
+  //  - proof_ids: list of ids of related bills
+  //  - cent: amount in cents
+  //
+  // body.proofs (table of bills):
+  //  - id: unique identifier
+  //  - url: url of the bill
+  //  - created_at: creation date of the bill
+  //  - type: type of operation ('purchase' or 'refund')
+  //
+  // body.after_sales_logs (table of refunds):
+  //  - id: unique identifier
+  //  - added_cents: extr expense for the refund
+  //  - refunded_cents: amount of reinbursment
+  //  - penalty_cents: amount penalty
+  //  - date
+  //
+  if (typeof data.proofs === 'undefined') {
+    data.proofs = [];
+  }
+  data.proofs = data.proofs.concat(body.proofs);
+
+  if (typeof data.pnrs === 'undefined') {
+    data.pnrs = [];
+  }
+  data.pnrs = data.pnrs.concat(body.pnrs);
+
+  if (typeof data.folders === 'undefined') {
+    data.folders = [];
+  }
+  data.folders = data.folders.concat(body.folders);
+
+  if (typeof data.after_sales_logs === 'undefined') {
+    data.after_sales_logs = [];
+  }
+  data.after_sales_logs = data.after_sales_logs.concat(body.after_sales_logs);
+}
+
+function fetchBills(requiredFields, entries, data, next) {
+  const bills = [];
+  // List of already managed proofs
+  const managedProofId = [];
+  for (const proof of data.proofs) {
+    if (!proof.url) {
+      // No need to go further.
+      continue;
+    }
+
+    // The proof can be duplicated, we only manage the one which were not taken care of already.
+    if (managedProofId.indexOf(proof.id) !== -1) {
+      // This proof is already dealt with
+      continue;
+    } else {
+      // Add to the managed proof list
+      managedProofId.push(proof.id);
+    }
+
+    // A bill can be linked to several pnrs, we retrieve all of them
+    // For some unknown reason, some users don't have pnrs backlinked to proofs,
+    // let's initialize the array with the one linked to the proof.
+    let linkedPNR = [data.pnrs.find(pnr => pnr.id === proof.pnr_id)];
+    try {
+      linkedPNR = data.pnrs.filter(pnr => pnr.proof_ids.indexOf(proof.id) !== -1);
+    } catch (e) {
+      // We do nothing with the error as linkedPNR is set anyway.
+      logger.error('linkedPNR');
+      logger.error(e);
+    }
+
+    // For some unknown reason, some users don't have system set for the pnr. By default we set it to sncf
+    linkedPNR = linkedPNR.map(pnr => {
+      if (typeof pnr.system === 'undefined') {
+        pnr.system = 'sncf';
+      }
+      return pnr;
+    });
+
+    // We try to find the list of the systems. there will be one bankoperation/proof/system
+    const systems = linkedPNR.reduce((sys, pnr) =>
+            sys.indexOf(pnr.system) === -1 ? sys.concat(pnr.system) : sys, []);
+
+    // Calculate the amount of each system because their is one operation per system.
+    for (const system of systems) {
+      const bill = {
+        pdfurl: proof.url,
+        type: 'train',
+        vendor: 'Captain Train',
+        date: moment(proof.created_at).hours(0)
+                                      .minutes(0)
+                                      .seconds(0)
+                                      .milliseconds(0),
+      };
+
+      // Get the list of refunds for the current bill
+      let refundID = [];
+      refundID = linkedPNR.filter(pnr => pnr.system === system).reduce((list, pnr) => list.concat(pnr.after_sales_log_ids), []);
+      let listRefund = [];
+      listRefund = refundID.reduce((list, id) => list.concat(data.after_sales_logs.find(asl => asl.id === id)), []);
+
+
+      if (proof.type === 'purchase') {
+        // Compute the sum of refunds for the current bill
+        const reinboursedAmount = listRefund.reduce((sum, rb) => sum - rb.added_cents + rb.refunded_cents, 0);
+        // We compute the amount of not reimbursed trips.
+        const paidAmount = linkedPNR.filter(pnr => pnr.system === system).reduce((sum, p) => sum + p.cents, 0);
+        // Get the the sum of penalties
+        const penaltiesAmount = listRefund.reduce((sum, rb) => sum + rb.penalty_cents, 0);
+        bill.amount = (paidAmount + reinboursedAmount + penaltiesAmount) / 100;
+      } else {
+        // Find the unique Refund based on the emission date
+        bill.amount = listRefund.find(refund => refund.date === proof.created_at).refunded_cents / 100;
+        bill.isRefund = true;
+      }
+
+      bills.push(bill);
+    }
+  }
+
+  entries.fetched = bills;
+  next();
+}
+
+function customFilterExisting(requiredFields, entries, data, next) {
+  filterExisting(logger, Bill)(requiredFields, entries, data, next);
+}
+
+function customSaveDataAndFile(requiredFields, entries, data, next) {
+  saveDataAndFile(logger, Bill, fileOptions, ['facture'])(
+      requiredFields, entries, data, next);
+}
+
+function buildNotifContent(requiredFields, entries, data, next) {
+  if (entries.filtered && entries.filtered.length > 0) {
+    const localizationKey = 'notification captain_train';
+    const options = {
+      smart_count: entries.filtered.length,
+    };
+    entries.notifContent = localization.t(localizationKey, options);
+  }
+
+  next();
+}

--- a/server/lib/link_bank_operation.coffee
+++ b/server/lib/link_bank_operation.coffee
@@ -15,7 +15,10 @@ class BankOperationLinker
     constructor: (options) ->
         @log = options.log
         @model = options.model
-        @identifier = options.identifier.toLowerCase()
+        if typeof(options.identifier) is 'string'
+            @identifier = [options.identifier.toLowerCase()]
+        else
+            @identifier = options.identifier.map((id) -> id.toLowerCase())
         @amountDelta = options.amountDelta or 0.001
         @dateDelta = options.dateDelta or 15
         @minDateDelta = options.minDateDelta or @dateDelta
@@ -59,11 +62,16 @@ class BankOperationLinker
             opAmount = Math.abs operation.amount
             amountDelta = Math.abs opAmount - amount
 
-            if operation.title.toLowerCase().indexOf(@identifier) >= 0 and \
-            amountDelta <= @amountDelta and \
-            amountDelta <= minAmountDelta
-                operationToLink = operation
-                minAmountDelta = amountDelta
+            # Select the operation to link based on the minimal amount
+            # difference to the expected one and if the label matches one
+            # of the possible labels (identifier)
+            for identifier in @identifier
+                if operation.title.toLowerCase().indexOf(identifier) >= 0 and \
+                amountDelta <= @amountDelta and \
+                amountDelta <= minAmountDelta
+                    operationToLink = operation
+                    minAmountDelta = amountDelta
+                    break
 
         if not operationToLink?
             callback()

--- a/server/lib/link_bank_operation.coffee
+++ b/server/lib/link_bank_operation.coffee
@@ -52,6 +52,10 @@ class BankOperationLinker
 
         try
             amount = Math.abs parseFloat entry.amount
+
+            # By default, an entry is an expense. If it is not, it should be
+            # declared as a refund: isRefund=true.
+            amount *= -1 if entry.isRefund? and entry.isRefund
         catch
             callback()
             return
@@ -60,12 +64,18 @@ class BankOperationLinker
         for operation in operations
 
             opAmount = Math.abs operation.amount
-            amountDelta = Math.abs opAmount - amount
+
+            # By default, an entry is an expense. If it is not, it should be
+            # declared as a refund: isRefund=true.
+            opAmount *= -1 if entry.isRefund? and entry.isRefund
+
+            amountDelta = Math.abs (opAmount - amount)
 
             # Select the operation to link based on the minimal amount
             # difference to the expected one and if the label matches one
             # of the possible labels (identifier)
             for identifier in @identifier
+
                 if operation.title.toLowerCase().indexOf(identifier) >= 0 and \
                 amountDelta <= @amountDelta and \
                 amountDelta <= minAmountDelta

--- a/server/models/bill.coffee
+++ b/server/models/bill.coffee
@@ -12,6 +12,7 @@ module.exports = Bill = cozydb.getModel 'Bill',
     binaryId: String
     fileId: String
     content: String
+    isRefund: Boolean
 
 
 Bill.all = (callback) ->


### PR DESCRIPTION
Fixes #178 
Buying tickets on Captain Train can lead to different operation labels: 'Capitain Train', 'Capitaine train' (for older operations), for Ouigo tickets bought on capitaine train, the operation is directly labelled 'Ouigo'. I then allowed to use an array as the operation identifier to allow to manage these situations. To maintain compatity with existing konnectors,  if the passed label is a string, it is put inside an array.

Capitain Train connector can also import refund bills, to be sure the bills are matched to the appropriate operation, in case on the same day, a train ticket is bought, and the same amount is refounded, the distinction was made between normal payments, and refunds. Refunds need do be declared as such, using isRefund attribute of the Bill object. 

Still known problem : if exacty the same operation is done on the same day (by twice the same ticket with same amount ), one of the two operations won't be linked to a bill, but the bill will be imported.