### PR TITLE
Improve notification management

### DIFF
--- a/server/controllers/konnectors.coffee
+++ b/server/controllers/konnectors.coffee
@@ -1,8 +1,7 @@
 Konnector = require '../models/konnector'
-localization = require '../lib/localization_manager'
-NotificationHelper = require 'cozy-notifications-helper'
-notification = new NotificationHelper 'konnectors'
 konnectorHash = require '../lib/konnector_hash'
+handleNotification = require '../lib/notification_handler'
+
 log = require('printit')
     prefix: 'konnector controller'
 
@@ -84,20 +83,3 @@ module.exports =
                             else
                                 handleNotification req.konnector, notifContent
                     res.status(200).send success: true
-
-
-# Create a notification telling how many data were imported.
-handleNotification = (konnector, notifContent) ->
-    notificationSlug = konnector.slug
-    model = konnectorHash[konnector.slug]
-
-    if notifContent?
-        prefix = localization.t 'notification prefix', name: model.name
-        notification.createOrUpdatePersistent notificationSlug,
-            app: 'konnectors'
-            text: "#{prefix} #{notifContent}"
-            resource:
-                app: 'konnectors'
-                url: "konnector/#{konnector.slug}"
-        , (err) ->
-            log.error err if err?

--- a/server/lib/importer.coffee
+++ b/server/lib/importer.coffee
@@ -1,12 +1,12 @@
 async = require 'async'
-NotificationHelper = require 'cozy-notifications-helper'
+handleNotification = require './notification_handler'
 log = require('printit')
     prefix: null
     date: true
 
 Konnector = require '../models/konnector'
 localization = require './localization_manager'
-notification = new NotificationHelper 'konnectors'
+
 
 
 # Runs import operation for a given konnector. Once done, it propagates a
@@ -35,28 +35,8 @@ module.exports = (konnector) ->
                     name: model.name
                 ]
 
-            notificationSlug = konnector.slug
-
-            if notifContents? \
-            and typeof(notifContents) is 'object' \
-            and notifContents.length
-                prefix = localization.t 'notification prefix', name: model.name
-                notifContents.filter((notif) -> notif).each (notif) ->
-                    notification.createOrUpdatePersistent notificationSlug,
-                        app: 'konnectors'
-                        text: "#{prefix} #{notif}"
-                        resource:
-                            app: 'konnectors'
-                            url: "konnector/#{konnector.slug}"
-                    , (err) ->
-                        log.error err if err?
-
-            else
-                # If there was an error before, but that last import was
-                # successful AND didn't not return a notification content, the
-                # error notification is simply removed.
-                notification.destroy notificationSlug, (err) ->
-                    log.error err if err?
+            # Through the notifications.
+            handleNotification(this, notifContents)
 
             # Update the lastAutoImport with the current date
             data = lastAutoImport: new Date()

--- a/server/lib/notification_handler.coffee
+++ b/server/lib/notification_handler.coffee
@@ -1,0 +1,46 @@
+konnectorHash = require '../lib/konnector_hash'
+localization = require '../lib/localization_manager'
+NotificationHelper = require 'cozy-notifications-helper'
+notification = new NotificationHelper 'konnectors'
+slugify = require 'cozy-slug'
+
+log = require('printit')
+    prefix: null
+    date: true
+
+# Create a notification telling how many data were imported.
+module.exports = (konnector, notifContents) ->
+    model = konnectorHash[konnector.slug]
+
+    prefix = localization.t 'notification prefix', name: model.name
+
+    for index of notifContents
+        notificationSlug = konnector.slug
+
+        # For each account of the konnector, generate a unique nofication slug
+        # based on credentials
+        for credential in konnector.accounts[index]
+            notificationSlug += "_#{slugify credential}"
+
+        notifContent = notifContents[index]
+        # Only through the notification if the notification content
+        # is defined. If no import was done, the notification content is
+        # undefined
+        if notifContent? \
+        and  typeof(notifContent) is 'string'
+            notification.createOrUpdatePersistent notificationSlug,
+                app: 'konnectors'
+                text: "#{prefix} #{notifContent}"
+                resource:
+                    app: 'konnectors'
+                    url: "konnector/#{konnector.slug}"
+            , (err) ->
+                log.error err if err?
+
+        else
+
+        # For this account, if there was an error before, but that last
+        # import was successful AND didn't not return a notification content,
+        # the error notification is simply removed.
+            notification.destroy notificationSlug, (err) ->
+                log.error err if err?


### PR DESCRIPTION
Manage notifications at the same location: previsously they were managed (the same) in the importer and the konnector controller.

This will help future maintenance of this function (previsously #250 was fixed only for automatic fetch).
Fixes the fact that only one notification could be sent for each konnector. Now one notification is raised per account.
Fixes empty notifications on manual fetch (fixes #250)