### PR TITLE
Fix sncf konnector (new html presentation)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,6 @@
     "no-use-before-define": 0,
     "import/no-unresolved": 0,
     "no-underscore-dangle": 0,
-    "max-len": [1, 80, 2, {"ignoreUrls": true}]
+    "max-len": [1, 120, 2, {"ignoreUrls": true}]
   }
 }
-

--- a/client/app/locales/en.coffee
+++ b/client/app/locales/en.coffee
@@ -176,6 +176,11 @@ module.exports =
 
     "konnector sncf reference": "Reference"
     "konnector sncf ticket choice": "Ticket choice"
+    "konnector sncf outward": "Outward"
+    "konnector sncf inward": "Inward"
+    "konnector sncf class": "Class"
+    "konnector sncf car": "car"
+    "konnector sncf place": "place"
 
     "konnector danger zone": "Danger zone"
     "konnector delete credentials": "Delete this configuration."

--- a/client/app/locales/fr.coffee
+++ b/client/app/locales/fr.coffee
@@ -176,6 +176,11 @@ module.exports =
 
     "konnector sncf reference": "Référence"
     "konnector sncf ticket choice": "Choix du billet"
+    "konnector sncf outward": "Aller"
+    "konnector sncf inward": "Retour"
+    "konnector sncf class": "Classe"
+    "konnector sncf car": "voiture"
+    "konnector sncf place": "place"
 
     "konnector danger zone": "Zone dangereuse"
     "konnector delete credentials": "Supprimer cette configuration."


### PR DESCRIPTION
Some orders are in the old html form so I kept the old `getEvents` function. Once they will have completely migrated to the new html pages we will be able to remove it.

The new html order page is built with Angular which eases the parsing because we can directly fetch the JSON from the API.

I modified the linter to allow max line length to 120 because some JQuery selectors are very long.

Closes https://github.com/cozy-labs/konnectors/issues/328