### PR TITLE
Add application token for runabove

### DIFF
--- a/server/konnectors/ovh_eu.coffee
+++ b/server/konnectors/ovh_eu.coffee
@@ -5,8 +5,7 @@ slug = 'ovh_eu'
 
 api =
     endpoint: 'ovh-eu'
-    appKey: 'zCqczKQV3Ka7ML2F'
-    appSecret: 'hVLSCmpmiLOQxrDCgzerKPly0RciWY7K'
+    appKey: 'aAPF1nke1brRoK5H'
+    appSecret: 'tVLYsO69677lcUksuXgV3dfegY68R6s9'
 
 connector = module.exports = baseOVHKonnector.createNew(api, name, slug)
-

--- a/server/konnectors/runabove.coffee
+++ b/server/konnectors/runabove.coffee
@@ -5,7 +5,7 @@ slug = 'runabove_ca'
 
 api =
     endpoint: 'runabove-ca'
-    appKey: ''
-    appSecret: ''
+    appKey: '6flmchEj8cORJnv9'
+    appSecret: '6CzGLAmbfsFfrIIscN7QCgEQd3ka7t90'
 
 connector = module.exports = baseOVHKonnector.createNew(api, name, slug)


### PR DESCRIPTION
I changed the ovh application tokens for a better application name/description.

I can't add tokens for Kimsufi fr/ca, Soyoustart fr/ca and ovh ca because I don't have an account on these services.

The OVH support said me that we can create an account on each service by creating an order and stop at the payment step.  Maybe I'm an idiot, but I tried and it never worked.

If there is no objection, I'll create an issue for each these services so anyone in the community that is client of one of them could create the associated application tokens.