### PR TITLE
Fix SFR mobile (wrong date handling)

### DIFF
--- a/server/konnectors/sfr_mobile.js
+++ b/server/konnectors/sfr_mobile.js
@@ -125,6 +125,27 @@ function parsePage(requiredFields, bills, data, next) {
   const $ = cheerio.load(data.html);
   const baseURL = 'https://espace-client.sfr.fr';
 
+  const firstBill = $('#facture');
+  const firstBillUrl = $('#lien-telecharger-pdf').attr('href');
+  // The year is not provided, but we assume this is the current year or that
+  // it will be provided if different from the current year
+  let firstBillDate = firstBill.find('tr.header h3').text().substr(17);
+  firstBillDate = moment(firstBillDate, 'D MMM YYYY');
+
+  const price = firstBill.find('tr.total td.prix').text()
+                                                .replace('€', '')
+                                                .replace(',', '.');
+
+  const bill = {
+    date: firstBillDate,
+    type: 'Mobile',
+    amount: parseFloat(price),
+    pdfurl: `${baseURL}${firstBillUrl}`,
+    vendor: 'Sfr'
+  };
+
+  bills.fetched.push(bill);
+
   $('#tab tr').each(function each() {
     let date = $(this).find('.date').text();
     let prix = $(this).find('.prix').text()
@@ -147,35 +168,6 @@ function parsePage(requiredFields, bills, data, next) {
     };
     bills.fetched.push(bill);
   });
-
-  // Parse the first bill in last since it does not provide the year, we will
-  // use the year of the next bill if available, else the current year
-  const previousBill = bills.fetched[0];
-  const previousBillDate = previousBill ? previousBill.date : new Date();
-  const firstBill = $('#facture');
-  const firstBillUrl = $('#lien-telecharger-pdf').attr('href');
-  let firstBillDate = firstBill.find('tr.header h3').text().substr(17);
-  firstBillDate = `${firstBillDate} ${previousBillDate.getFullYear()}`;
-  firstBillDate = moment(firstBillDate, 'D MMM YYYY');
-
-  // If the previous was issued in an earlier month, we are in a new year
-  if (previousBill && (firstBillDate.getMonth() < previousBillDate.getMonth())) {
-    firstBillDate.setFullYear(firstBillDate.getFullYear() + 1);
-  }
-
-  const price = firstBill.find('tr.total td.prix').text()
-                                                .replace('€', '')
-                                                .replace(',', '.');
-
-  const bill = {
-    date: firstBillDate,
-    type: 'Mobile',
-    amount: parseFloat(price),
-    pdfurl: `${baseURL}${firstBillUrl}`,
-    vendor: 'Sfr'
-  };
-
-  bills.fetched.unshift(bill);
 
   connector.logger.info('Successfully parsed the page');
   next();


### PR DESCRIPTION
If there is no year provided when using moment, moment will use the current year.
SFR does not provide the year for the last bill, but I guess they would if the bill's year was different from the current year.

This PR simplifies the code and fixes the previous issue (mix of Date/moment instances).