### PR TITLE
Reset import Error on deletion of an account

### DIFF
--- a/client/app/views/konnector.coffee
+++ b/client/app/views/konnector.coffee
@@ -386,6 +386,8 @@ target="_blank">
                 @model.set 'lastAutoImport', null
                 @model.set 'accounts', [{}]
                 @model.set 'password', '{}'
+                @model.set 'importErrorMessage', null
+
                 window.router.navigate '', trigger: true
 
 

--- a/server/controllers/konnectors.coffee
+++ b/server/controllers/konnectors.coffee
@@ -40,6 +40,7 @@ module.exports =
 
         data =
             lastAutoImport: null
+            importErrorMessage: null
             accounts: []
             password: '{}'
 


### PR DESCRIPTION
Fixes #381

This does not remove the import warning when deleting a specific configuration, but only when deleting the whole configuration (all the accounts attached to the konnector). It is not easy to have a "by configuration" management of the warning, as the importErrorMessage is managed on the konnector level, not an the account level.