### PR TITLE
Fix env dev on clean clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "test": "sh scripts/lint.sh && sh scripts/tests.sh",
     "test:server": "sh scripts/tests.sh",
     "lint": "sh scripts/lint.sh",
+    "prewatch:client": "cd client && npm install",
     "start": "node build/server.js",
     "watch": "npm-run-all --parallel 'watch:*'",
     "watch:client": "cd client && webpack --display-modules --display-chunks --watch",

--- a/server/init/konnectors.coffee
+++ b/server/init/konnectors.coffee
@@ -83,8 +83,8 @@ patch381 = (callback) ->
 patchOnlineNet = (callback) ->
     Konnector.request 'bySlug', key: 'online_net', (err, konnectors) ->
         return callback err if err
-        if not konnectors.length
-            callback()
+        return callback() unless konnectors.length
+
         konnector = konnectors[0]
         accounts = konnector.accounts
         if accounts[0]? && accounts[0].username
@@ -94,7 +94,7 @@ patchOnlineNet = (callback) ->
                 account.login = account.username
                 delete account.username
                 newAccounts.push(account)
-            
+
             konnector.updateAttributes accounts: newAccounts, (err) ->
                 return callback err if err
 


### PR DESCRIPTION
Fixes unwanted errors when we start a watch task fromn a clean environment (clean clone and empty DS)