### PR TITLE
Add Vue tools and libs

### DIFF
--- a/client/app/app.vue
+++ b/client/app/app.vue
@@ -1,6 +1,10 @@
 <template lang="pug">
     div(role="application")
-        h1 Hello World
+        ul
+            li: router-link(to="/foo") foo
+            li: router-link(to="/bar") bar
+
+        router-view
 </template>
 
 

--- a/client/app/components/examples/bar.vue
+++ b/client/app/components/examples/bar.vue
@@ -1,0 +1,3 @@
+<template lang="pug">
+    div Bar
+</template>

--- a/client/app/components/examples/foo.vue
+++ b/client/app/components/examples/foo.vue
@@ -1,3 +1,8 @@
 <template lang="pug">
-    div Foo
+    div
+        | Foo
+        // - Test translation through vue-polyglot filter, wiht vars & counters
+        p {{ 'file error' | t }}
+        p {{ 'notification prefix' | t({name: 'foobar'}) }}
+        p {{ 'notification commits' | t({smart_count: 8}) }}
 </template>

--- a/client/app/components/examples/foo.vue
+++ b/client/app/components/examples/foo.vue
@@ -1,0 +1,3 @@
+<template lang="pug">
+    div Foo
+</template>

--- a/client/app/index.js
+++ b/client/app/index.js
@@ -1,11 +1,25 @@
 import Vue from 'vue'
-import App from './app'
+import VueRouter from 'vue-router'
+
+import app from './app'
+
+import foo from './components/examples/foo'
+import bar from './components/examples/bar'
+
+Vue.use(VueRouter)
+
+
+const routes = [
+    { path: '/foo', component: foo, alias: '/' },
+    { path: '/bar', component: bar }
+]
+
+const router = new VueRouter({ routes })
 
 
 document.addEventListener('DOMContentLoaded', function initialize () {
     new Vue({
-        el: '[role=application]',
-        render: h => h(App),
-        components: { App }
-    })
+        router,
+        render: h => h(app)
+    }).$mount('[role=application]')
 })

--- a/client/app/index.js
+++ b/client/app/index.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
+import VuePolyglot from './plugins/vue-polyglot'
 
 import app from './app'
 
@@ -7,6 +8,7 @@ import foo from './components/examples/foo'
 import bar from './components/examples/bar'
 
 Vue.use(VueRouter)
+Vue.use(VuePolyglot)
 
 
 const routes = [

--- a/client/app/plugins/vue-polyglot.js
+++ b/client/app/plugins/vue-polyglot.js
@@ -1,0 +1,48 @@
+/**
+ * Vue.js plugin that wrap AirBnB Polyglot lib in a Vue filter.
+ *
+ * Use it in your mustaches, with options if needed
+ * (see http://airbnb.io/polyglot.js/#interpolation):
+ *
+ * ```html
+ * <p>{{ 'key to translate' | t }}</p>
+ * <p>{{ 'key that handle a var' | t({name: 'foo'}) }}
+ * ```
+ */
+
+'use strict';
+
+import Polyglot from 'node-polyglot'
+import en from '../locales/en'
+
+
+const init = function () {
+  const polyglot = new Polyglot({
+    phrases: en,
+    locale: 'en'
+  })
+
+  const lang = document.documentElement.getAttribute('lang')
+
+  if (lang && lang != 'en') {
+    try {
+      const dict = require(`../locales/${lang}`)
+      polyglot.extend(dict)
+      polyglot.locale(lang)
+    } catch (e) {
+      console.error(`The requested dict phrases for "${lang}" cannot be loaded`)
+    }
+  }
+
+  return polyglot
+}
+
+
+export default {
+  install (Vue) {
+    const polyglot = init()
+
+    Vue.prototype.$t = polyglot.t.bind(polyglot)
+    Vue.filter('t', Vue.prototype.$t)
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "node-polyglot": "2.0.0",
     "normalize.css": "5.0.0",
     "vue": "2.0.3",
     "vue-resource": "1.0.3",

--- a/server/controllers/index.coffee
+++ b/server/controllers/index.coffee
@@ -19,10 +19,9 @@ module.exports.main = (req, res) ->
         console.log err if err?
 
         {konnectors, instance, folders} = results
-        locale = instance?.locale or 'en'
-        res.render 'index', imports: """
-            window.locale = "#{locale}";
-            window.initKonnectors = #{JSON.stringify konnectors};
-            window.initFolders = #{JSON.stringify folders};
-        """
 
+        res.render 'index',
+          locale: instance?.locale or 'en'
+          imports:
+            konnectors: konnectors
+            folders: folders

--- a/server/views/index.jade
+++ b/server/views/index.jade
@@ -1,6 +1,6 @@
 doctype html
-html(lang="en")
-  
+html(lang=locale)
+
   meta(charset="utf-8")
   meta(name="viewport", content="width=device-width, initial-scale=1")
 
@@ -8,7 +8,12 @@ html(lang="en")
   
   link(rel="stylesheet" href="/fonts/fonts.css")
   link(rel="stylesheet" href="app#{hash}.css")
-    
+
+  if imports
+    script.
+      window.initKonnectors = !{JSON.stringify(imports.konnectors)}
+      window.initFolders = !{JSON.stringify(imports.folders)}
   script(src="app#{hash}.js" defer=true)
 
   div(role="application")
+    


### PR DESCRIPTION
This PR enables two features in the Vue.js stack:

- vue-router: is now declared and loaded by index with an example set of routes
- vue-polyglot: to enable localization in templates through a vue filter