### PR TITLE
Use-cases and Categories Documentation

### DIFF
--- a/docs/client-side-connector-configuration.md
+++ b/docs/client-side-connector-configuration.md
@@ -1,0 +1,71 @@
+
+---
+
+# Cozy MyAccounts: Connector configuration
+
+## Color
+
+The account connector can define a simple color or a gradient color to be used when displayed (for example as background). Here, it's important to know that the property is not a simple color but a css property. It's why the account connector color property will be defined like an object.
+
+We keep a simple color definition in all cases, because if we have a gradient as background, we can also need a simple for others interface elements (borders, customized svg...).
+
+For a simple color account connector:
+
+```javascript
+// my_connector.js
+
+    ...
+    color: {
+        // the simple color hexadecimal definition
+        hex: '#A7B5C6',
+        // property used to display the connector background in the modal,
+        // could be different from the hexColor property
+        css: '#A7B5C6'
+    }
+    ...
+```
+
+For a 'complex' color account connector:
+
+```javascript
+// my_connector.js
+
+    ...
+    name: "My connector"
+    fields: ...
+    models: ...
+    ...
+
+    color: {
+        // a default simple color still available, eventually for other usages
+        hex: '#9E0017',
+        // css property for linear gradient
+        css: 'linear-gradient(90deg, #EF0001 0%, #9E0017 100%)'
+    }
+    ...
+```
+
+If a color property is not defined by the account connector, that will fallback to the default ```hex``` and ```css``` value which is ```#A7B5C6```.
+
+## Category
+
+An account connector can define a category to be listed in. This category is single because a connected can not be listed in many different categories. Here is the connector category definition:
+
+```javascript
+// my_connector.js
+
+    ...
+    name: "My connector"
+    fields: ...
+    models: ...
+    ...
+
+    category: 'health',
+    ...
+```
+
+__⚠️ Important notes:__
+
+The defined category must be authorized by the MyAccounts application in order to be listed in. You can see more about the authorized categories in the [MyAccounts server side configuration documentation](server-side-configuration.md).
+
+If the account connector define a category which is authorized, it will be used. Otherwise, (if not 'valid' or not defined as well) that will fallback to the default name, which is ```others```.

--- a/docs/client-side-connector-configuration.md
+++ b/docs/client-side-connector-configuration.md
@@ -45,11 +45,11 @@ For a 'complex' color account connector:
     ...
 ```
 
-If a color property is not defined by the account connector, that will fallback to the default ```hex``` and ```css``` value which is ```#A7B5C6```.
+If a color property is not defined by the account connector, that will fallback to the default `hex` and `css` value which is `#A7B5C6`.
 
 ## Category
 
-An account connector can define a category to be listed in. This category is single because a connected can not be listed in many different categories. Here is the connector category definition:
+An account connector can define a category to be listed in. This category is single because a connector can not be listed in many different categories. Here is the connector category definition:
 
 ```javascript
 // my_connector.js
@@ -68,4 +68,4 @@ __⚠️ Important notes:__
 
 The defined category must be authorized by the MyAccounts application in order to be listed in. You can see more about the authorized categories in the [MyAccounts server side configuration documentation](server-side-configuration.md).
 
-If the account connector define a category which is authorized, it will be used. Otherwise, (if not 'valid' or not defined as well) that will fallback to the default name, which is ```others```.
+If the account connector define a category which is authorized, it will be used. Otherwise, (if not 'valid' or not defined as well) that will fallback to the default name, which is `others`.

--- a/docs/client-side-use-cases-configuration.md
+++ b/docs/client-side-use-cases-configuration.md
@@ -16,17 +16,17 @@ This document describes the context of using _use-cases_ in MyAccounts app, how 
 What are use-cases?
 -------------------
 
-A **use-case** is a way to sort and filter konnectors by an arbitrary denominator (e.g. _all konnectors that concerns billing_). It allow a user to browse available konnectors in a different way than browsing by categories. I allow the user to discover some konnectors by selecting first a _use-case_ (aka a scenario) that cover usages, and see what konnectors can be suggested.
+A **use-case** is a way to sort and filter konnectors by an arbitrary denominator (e.g. _all konnectors that concerns billing_). It allows a user to browse available konnectors in a different way than browsing by categories. The user can discover some konnectors by selecting first a _use-case_ (aka a scenario) that cover usages, and see what konnectors can be suggested.
 
-_MyAccounts_ can provides many _use-cases_, that can be configured, which mean a hoster can offer a different way to discover available konnectors (aka present different _use-cases_).
+_MyAccounts_ can provide many _use-cases_, that can be configured, which means that an hoster can offer a different way to discover available konnectors (aka present different _use-cases_).
 
 
 How to define a use-case?
 -------------------------
 
-All _use-cases_ are declared in a manifest, built-in the client app, at `client/app/contexts/<context>/index.json`. Its architecture is defined ine the _Architecture of the manifest_ section below.
+All _use-cases_ are declared in a manifest, built-in the client app, at `client/app/contexts/<context>/index.json`. Its architecture is defined in the _Architecture of the manifest_ section below.
 
-The `context` value is the one defines in which context _MyAccounts_ app run. There must be a `cozy` context, which is the default one available. Later, all partners can defines their own _use-cases_ by adding a new context, with a dedicated manifest and locales (see _Localization_ section below about translations).
+The `context` value is the one that defines in which context _MyAccounts_ app run. There must be a `cozy` context, which is the default one available. Later, all partners can define their own _use-cases_ by adding a new context, with a dedicated manifest and locales (see _Localization_ section below about translations).
 
 Adding a _use-case_ simply mean adding a new object into the _use-cases_ array, that provides the following keys (see the _Architecture_ section below for a complete list and informations):
 
@@ -51,11 +51,11 @@ it defines if this _use-case_ is the default one. When we access the _use-cases_
 
 Sometimes, we need to directly open a _use-case_ screen without passing by the `/discover` view (this is the case when user access to _MyAccounts_ from the onboarding). In this case, this is the default _use-case_ which is displayed.
 
-⚠️ if the _use-cases_ array contains more than one _use-case_ with a default key set to `true`, then only the first one find in the array is considered as the default one.
+⚠️ if the _use-cases_ array contains more than one _use-case_ with a default key set to `true`, then only the first one found in the array is considered as the default one.
 
 ### The `incentive`
 
-When displaying a _use-case_ screen, a konnector can be highlighted first to incitate the user to first configure this one. Into the `konnectors` array, the _Konnector Object_ can define a `default` key at `true` to declares it as the _incentive_ one.
+When displaying a _use-case_ screen, a konnector can be highlighted first to incitate the user to first configure this one. Into the `konnectors` array, the _Konnector Object_ can define a `default` key at `true` to declare it as the _incentive_ one.
 
 ⚠️ as for the _use-cases_ array, if more than one konnector has a `default` key set to true, only the first one in the array is considered as the _incentive_ one.
 

--- a/docs/client-side-use-cases-configuration.md
+++ b/docs/client-side-use-cases-configuration.md
@@ -53,7 +53,7 @@ Sometimes, we need to directly open a _use-case_ screen without passing by the `
 
 ⚠️ if the _use-cases_ array contains more than one _use-case_ with a default key set to `true`, then only the first one found in the array is considered as the default one.
 
-### The `incentive`
+### The _incentive_
 
 When displaying a _use-case_ screen, a konnector can be highlighted first to incitate the user to first configure this one. Into the `konnectors` array, the _Konnector Object_ can define a `default` key at `true` to declare it as the _incentive_ one.
 

--- a/docs/client-side-usecases configuration.md
+++ b/docs/client-side-usecases configuration.md
@@ -1,0 +1,105 @@
+last edit: 2016-11-02 11:13
+author: m4dz <code@m4dz.net>
+
+---
+
+
+Cozy MyAccounts Client Use-case
+===============================
+
+Abstract
+--------
+
+This document describes the context of using _use-cases_ in MyAccounts app, how they are related to the app and the stack, and how to customize them in hosting context.
+
+
+What are use-cases?
+-------------------
+
+A **use-case** is a way to sort and filter konnectors by an arbitrary denominator (e.g. _all konnectors that concerns billing_). It allow a user to browse available konnectors in a different way than browsing by categories. I allow the user to discover some konnectors by selecting first a _use-case_ (aka a scenario) that cover usages, and see what konnectors can be suggested.
+
+_MyAccounts_ can provides many _use-cases_, that can be configured, which mean a hoster can offer a different way to discover available konnectors (aka present different _use-cases_).
+
+
+How to define a use-case?
+-------------------------
+
+All _use-cases_ are declared in a manifest, built-in the client app, at `client/app/contexts/<context>/index.json`. Its architecture is defined ine the _Architecture of the manifest_ section below.
+
+The `context` value is the one defines in which context _MyAccounts_ app run. There must be a `cozy` context, which is the default one available. Later, all partners can defines their own _use-cases_ by adding a new context, with a dedicated manifest and locales (see _Localization_ section below about translations).
+
+Adding a _use-case_ simply mean adding a new object into the _use-cases_ array, that provides the following keys (see the _Architecture_ section below for a complete list and informations):
+
+- `slug`: `<String>` the slugname for the use-case
+- `konnectors`: `<Array[Obj]>` an array of objects defining the konnectors
+- `figure`: `<String>` the picture file that illustrate the use-case
+- `color`: `<Color>` a color object that defines the color of the use-case
+- `default`: `<Bool>` a `true|false` value that defines this use-case as the default one
+- `important`: `<Bool>` should this `use-case` a recommended one?
+
+For its first release, the manifest will be built-in the client app, to get it ready to work out-of-the-box. With the stack v2, we should serve the manifest behind a dedicated endpoint, so we won't need to build a specific version of _MyAccounts_ each time we need to provides different _use-cases_.
+
+
+Default values
+--------------
+
+There's two kind of default values for a _use-case_:
+
+### the `default` key
+
+it defines if this _use-case_ is the default one. When we access the _use-cases_ screen (`/discover` URI), it offers a list of _use-cases_ screen, each one redirecting to a _use-case_ view (or the konnector if the _use-case_ only contains one).
+
+Sometimes, we need to directly open a _use-case_ screen without passing by the `/discover` view (this is the case when user access to _MyAccounts_ from the onboarding). In this case, this is the default _use-case_ which is displayed.
+
+⚠️ if the _use-cases_ array contains more than one _use-case_ with a default key set to `true`, then only the first one find in the array is considered as the default one.
+
+### The `incentive`
+
+When displaying a _use-case_ screen, a konnector can be highlighted first to incitate the user to first configure this one. Into the `konnectors` array, the _Konnector Object_ can define a `default` key at `true` to declares it as the _incentive_ one.
+
+⚠️ as for the _use-cases_ array, if more than one konnector has a `default` key set to true, only the first one in the array is considered as the _incentive_ one.
+
+
+Localization
+------------
+
+There's 2 kind of information that need to be translated:
+
+1. the _use-case_ name (mandatory)
+2. a _use-case_ description (optionnal)
+
+To avoid having all translations for all use-cases embeded into the build app, even when the _use-cases_ aren't declared in the given context, all locales related to a context should belong to the context directly, so located in `client/app/contexts/<context>/locales/<lang>.json` file.
+
+It uses a syntax like `use-case <slug> title` and `use-case <slug> description` as translation keys. Transifex remains the centralized tool for all translations, contexts included.
+
+
+Architecture of the manifest
+----------------------------
+
+A manifest should have the following structure:
+
+```json
+{
+  "use-cases": [{
+    "slug": "the use-case slug",
+    "konnectors": [{
+      "slug": "konnector-to-add-slugname",
+      "default": true,
+      "important": true
+    }],
+    "figure": "use-case_picture_file_name.ext",
+    "color": {
+      "css": "the CSS value of the use-case color"
+    },
+    "default": true,
+    "important": true
+  }]
+}
+```
+
+The `important` key indicate if the _use-case_/_konnector_ is recommended or not.
+
+The `default` key indicate if:
+
+- the _use-case_ is the one displayed by default (_onboarding_ view)
+- the _konnector_ into the list is the incentive one

--- a/docs/server-side-configuration.md
+++ b/docs/server-side-configuration.md
@@ -12,15 +12,16 @@ Instead, they need to be configured on the served side, in a simple way, from a 
 ```javascript
 {
     authorizedCategories:
-        {
-            'insurance': 1,
-            'communication': 1,
-            'energy': 1,
-            'productivity': 1,
-            'health': 1,
-            'travel': 1,
-            'life': 1
-        }
+        [
+            'telecom',
+            'isp',
+            'energy',
+            'host_provider',
+            'productivity',
+            'health',
+            'social',
+            'transport'
+        ]
 }
 ```
 

--- a/docs/server-side-configuration.md
+++ b/docs/server-side-configuration.md
@@ -1,0 +1,37 @@
+
+---
+
+# Cozy MyAccounts: Server side configuration
+
+## Authorized categories list
+
+The MyAccounts categories names list won't be automatically computed from available connectors in order to keep it clear and relevant for all Cozy users with a growing number of connectors.
+
+Instead, they need to be configured on the served side, in a simple way, from a config file. This is a list of categories authorized to be used:
+
+```javascript
+{
+    authorizedCategories:
+        {
+            'insurance': 1,
+            'communication': 1,
+            'energy': 1,
+            'productivity': 1,
+            'health': 1,
+            'travel': 1,
+            'life': 1
+        }
+}
+```
+
+In an account connector's file, the category will just be defined like:
+
+```javascript
+// my_connector.js
+
+    ...
+    category: 'health',
+    ...
+```
+
+If the account connector define a category available in the ```authorizedCategories ``` object, it will be used. Otherwise, (if not 'valid' or not defined) that will fallback to the default category name which is ```others```.

--- a/docs/server-side-configuration.md
+++ b/docs/server-side-configuration.md
@@ -34,4 +34,4 @@ In an account connector's file, the category will just be defined like:
     ...
 ```
 
-If the account connector define a category available in the ```authorizedCategories ``` object, it will be used. Otherwise, (if not 'valid' or not defined) that will fallback to the default category name which is ```others```.
+If the account connector define a category available in the `authorizedCategories` object, it will be used. Otherwise, (if not 'valid' or not defined) that will fallback to the default category name which is `others`.


### PR DESCRIPTION
This PR adds documentation about _use-cases_ and _categories_ behaviors in the new new client-side app.

📌 _Note about use-cases_: a _use-case_ is a way to sort available connectors in a different manner than simple categories, to provides to the user a way to discover some connectors organized by themes. You can see a mockup of the [_discover_ screen](https://marvelapp.com/77d7jfg/screen/14185063) (which presents configured _use-cases_), and a [_use-case_ screen](https://marvelapp.com/77d7jfg/screen/14184978) (accessible from the _discover_ screen, or in the onbaording) too.