### PR TITLE
Fix for missing path include in #560

### DIFF
--- a/server/lib/importer.coffee
+++ b/server/lib/importer.coffee
@@ -3,6 +3,7 @@ handleNotification = require './notification_handler'
 log = require('printit')
     prefix: null
     date: true
+path = require 'path'
 
 Konnector = require '../models/konnector'
 localization = require './localization_manager'


### PR DESCRIPTION
Hi,

After upgrade to 0.7.4, Konnectors is heavily broken. This is due to a bad `path` use I made in #560, forgetting to `require` the package.

It was fixed by @jacquarg in #572 but only partially.

Some background about this:
* @m4dz asked me to use `path.join` everywhere in #560, which I did. Unfortunately, I forgot to `require('path')` in the files which were not already using it, which lead to a fatal error. Sorry for that... :/
* @jacquarg noticed it in #572 but only partially fixed it.
* @aenario published 0.7.4, and then the bug which was only on `master` branch (and not affecting much users) landed in every up-to-date Cozy :/

Then, I think, now, no-one can actually use Konnectors anymore. I tested this PR, and apart from #584 (which is unrelated I think), everything should be working. [Here](https://github.com/Phyks/konnectors/tree/build) is my built branch to test the fix, it should be working.

@aenario I think this should be merged quickly and as soon as we agree that the bug is solved, a new Konnectors version should be released. Or maybe we can revert to 0.7.3 in the meantime?

Sorry about that :/