### PR TITLE
`vue` and `vue-loader` modules version mismatch

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "node-polyglot": "2.0.0",
     "normalize.css": "5.0.0",
-    "vue": "2.0.7",
+    "vue": "2.0.8",
     "vue-resource": "1.0.3",
     "vue-router": "2.0.1"
   },
@@ -29,7 +29,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "2.3.1",
     "svg-sprite-loader": "0.0.31",
-    "vue-loader": "^9.9.5",
+    "vue-loader": "9.9.5",
     "vue-style-loader": "1.0.0"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "node-polyglot": "2.0.0",
     "normalize.css": "5.0.0",
-    "vue": "2.0.5",
+    "vue": "2.0.7",
     "vue-resource": "1.0.3",
     "vue-router": "2.0.1"
   },
@@ -29,7 +29,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "2.3.1",
     "svg-sprite-loader": "0.0.31",
-    "vue-loader": "9.8.1",
+    "vue-loader": "^9.9.5",
     "vue-style-loader": "1.0.0"
   }
 }


### PR DESCRIPTION
Note: `vuejs` is upgrading very often; lets upgrade dependencies very often too (or errors occur)

see also https://github.com/cozy-labs/konnectors/pull/578
