### PR TITLE
Create missing target folder on import

### DIFF
--- a/server/controllers/konnectors.coffee
+++ b/server/controllers/konnectors.coffee
@@ -60,7 +60,6 @@ module.exports =
     # No import is started when the konnector is already in the is importing
     # state.
     import: (req, res, next) ->
-
         # Don't run a new import if an import is already running.
         if req.konnector.isImporting
             res.send 400, message: 'konnector is importing'

--- a/server/lib/save_data_and_file.coffee
+++ b/server/lib/save_data_and_file.coffee
@@ -1,6 +1,7 @@
 async = require 'async'
 naming = require './naming'
 moment = require 'moment'
+Folder = require '../models/folder'
 File = require '../models/file'
 
 
@@ -29,9 +30,9 @@ module.exports = (log, model, options, tags) ->
 
             createFileAndSaveData = (entry, entryLabel) ->
                 # Legacy code: Date is not used in File Model
-
                 pdfurl = entry.pdfurl
-                File.createNew fileName, path, pdfurl, tags, onCreated
+                Folder.mkdirp path, ->
+                    File.createNew fileName, path, pdfurl, tags, onCreated
 
             onCreated = (err, file) ->
                 if err
@@ -101,14 +102,13 @@ checkForMissingFiles = (options, callback) ->
         File.isPresent path, (err, isPresent) ->
 
             # If it's there, it does nothing.
-            if isPresent or not entry.pdfurl?
-                done()
+            return done() if isPresent or not entry.pdfurl?
 
             # If it's not there, it creates it.
-            else
-                url = entry.pdfurl
-                path = folderPath
+            url = entry.pdfurl
+            path = folderPath
 
+            Folder.mkdirp path, ->
                 File.createNew fileName, path, url, tags, (err, file) ->
 
                     if err

--- a/server/models/folder.coffee
+++ b/server/models/folder.coffee
@@ -40,6 +40,8 @@ Folder.createNewFolder = (folder, callback) ->
 
 
 Folder.mkdir = (path, callback) ->
+    return callback(null, {path}) if path.length is 0
+
     Folder.isPresent path, (err, isPresent) ->
         parts = path.split '/'
         name  = parts.pop()

--- a/server/models/folder.coffee
+++ b/server/models/folder.coffee
@@ -27,7 +27,37 @@ Folder.allPath = (callback) ->
         callback err, folders
 
 
+Folder.isPresent = (fullPath, callback) ->
+    Folder.request "byFullPath", key: fullPath, (err, folders) ->
+        return callback err if err
+        callback null, folders?.length > 0
+
+
 Folder.createNewFolder = (folder, callback) ->
     Folder.create folder, (err, newFolder) ->
         return callback err if err
         callback null, newFolder
+
+
+Folder.mkdir = (path, callback) ->
+    Folder.isPresent path, (err, isPresent) ->
+        parts = path.split '/'
+        name  = parts.pop()
+        path  = parts.join '/'
+
+        if isPresent
+            callback null, {name, path}
+        else
+            Folder.createNewFolder {name, path}, callback
+
+
+
+Folder.mkdirp = (path, callback) ->
+    recurseCreate = (err, folder) ->
+        # Remove the initial `/` to prevent empty folder creation
+        if folder.path.substring(1).split('/').length > 1
+            Folder.mkdir folder.path, recurseCreate
+        else
+            Folder.mkdir folder.path, callback
+
+    Folder.mkdir path, recurseCreate


### PR DESCRIPTION
This PR introduces a way to create missing target folder on import. When an import is triggered, if the target folder doesn't exists (even if it's a nested folder), the full path is created. It's something similar to a `mkdir -p $TARGET_PATH` called in the DS _Folder_ doctype before executing import.