### PR TITLE
Fix magic folder autoselect

### DIFF
--- a/client/app/views/konnector.coffee
+++ b/client/app/views/konnector.coffee
@@ -290,7 +290,9 @@ module.exports = class KonnectorView extends BaseView
                                             not pathName\
                                         )
                             fieldHtml += """
-    <option #{if isSelected then "selected" else ""} value="#{path.id}">#{path.path}</option>
+    <option #{if isSelected then "selected" else ""} value="#{path.id}">
+        #{path.path}
+    </option>
     """
                 fieldHtml += """
     <option selected value="#{magicFolder}">#{magicFolder}</option>

--- a/client/app/views/konnector.coffee
+++ b/client/app/views/konnector.coffee
@@ -277,14 +277,20 @@ module.exports = class KonnectorView extends BaseView
                     # Displayed label is the path of the folder.
                     for path in @paths
                         if path.path is pathName
-                            addMagicFolder = false if path.path is magicFolder
+                            addMagicFolder = false
                             fieldHtml += """
     <option selected value="#{path.id}">#{path.path}</option>
     """
                             selectedPath = path
                         else
+                            if path.path is magicFolder
+                                addMagicFolder = false
+                            isSelected = path.path is magicFolder and (\
+                                            pathName is magicFolder or\
+                                            not pathName\
+                                        )
                             fieldHtml += """
-    <option value="#{path.id}">#{path.path}</option>
+    <option #{if isSelected then "selected" else ""} value="#{path.id}">#{path.path}</option>
     """
                 fieldHtml += """
     <option selected value="#{magicFolder}">#{magicFolder}</option>


### PR DESCRIPTION
This PR introduces some changes in the magic folder for a konnector:
- adds the magic folder at end and select it if the konector isn't configured and the folder doesn't exists
- select the magic folder into the list if it already exists and the konnector isn't configured
- select the right folder (the selected one or the magic folder when created) when the konnector is configured

It should fix the select value issue.