### PR TITLE
Change default password field

### DIFF
--- a/client/app/views/konnector.coffee
+++ b/client/app/views/konnector.coffee
@@ -442,7 +442,7 @@ target="_blank">
                 alert t 'konnector deleted'
                 @model.set 'lastAutoImport', null
                 @model.set 'accounts', [{}]
-                @model.set 'password', '{}'
+                @model.set 'password', null
                 @model.set 'importErrorMessage', null
 
                 window.router.navigate '', trigger: true

--- a/server/controllers/konnectors.coffee
+++ b/server/controllers/konnectors.coffee
@@ -57,7 +57,7 @@ module.exports =
             lastAutoImport: null
             importErrorMessage: null
             accounts: []
-            password: '{}'
+            password: null
 
         req.konnector.updateAttributes data, (err, konnector) ->
             return next err if err

--- a/server/models/konnector.coffee
+++ b/server/models/konnector.coffee
@@ -15,7 +15,7 @@ module.exports = Konnector = cozydb.getModel 'Konnector',
     accounts: [Object], default: [{}]
     password:
         type: String
-        default: '[{}]'
+        default: null
     lastSuccess: Date
     lastImport: Date
     lastAutoImport: Date
@@ -60,9 +60,10 @@ Konnector::injectEncryptedFields = (callback) ->
     try
         parsedPasswords = JSON.parse @password
         @cleanFieldValues()
-        for passwords, i in parsedPasswords
-            if @accounts[i]?
-                @accounts[i][name] = val for name, val of passwords
+        if parsedPasswords?
+            for passwords, i in parsedPasswords
+                if @accounts[i]?
+                    @accounts[i][name] = val for name, val of passwords
     catch error
         log.error "Attempt to retrieve password for #{@slug} failed: #{error}"
         log.error @password


### PR DESCRIPTION
Konnectors has been added on onboarding. Thus, we want to add it on Cozy template.

Before registering, data-system does not have access to the encryption keys. 
However, the default password field is '{}'. 
Also take note that konnectors can't create konnectors during the intialization because data-system tries to encrypt it.


This PR changes default password field to allow konnector to create all konnectors before registering.