### PR TITLE
Add use case dialogs content + some generic dialog component styles

### DIFF
--- a/client/app/components/AccountDialog.jsx
+++ b/client/app/components/AccountDialog.jsx
@@ -25,7 +25,10 @@ const AccountDialog = ({ t, item, iconName, enableDefaultIcon }) => (
   <div role='dialog' class='account-dialog'>
     <div class='wrapper'>
       <div role='contentinfo'>
-        <header style={{background: item.color.css || 'white'}}>
+        <header
+          class='dialog-header'
+          style={{background: item.color.css || 'white'}}
+        >
           <svg class='item-icon'>
             <use
               xlinkHref={getIcon(iconName || item.slug, enableDefaultIcon)}

--- a/client/app/components/AccountDialog.jsx
+++ b/client/app/components/AccountDialog.jsx
@@ -4,21 +4,39 @@ import { translate } from '../plugins/preact-polyglot'
 import { withRouter } from 'react-router'
 
 const CloseButton = withRouter(({ router }) => (
-  <button role='close' onClick={router.goBack}>Close</button>
+  <div class='close-button' role='close' onClick={router.goBack} />
 ))
 
-const AccountDialog = ({ t, item }) => (
-  <div role='dialog'>
+// Fallback to get the item icon and avoid error if not found
+// with a possible default icon
+const getIcon = (iconName, enableDefaultIcon) => {
+  let icon = ''
+  try {
+    icon = require(`../assets/icons/${iconName}.svg`)
+  } catch (e) {
+    if (enableDefaultIcon) {
+      icon = require('../assets/icons/default_myaccount.svg')
+    }
+  }
+  return icon
+}
+
+const AccountDialog = ({ t, item, iconName, enableDefaultIcon }) => (
+  <div role='dialog' class='account-dialog'>
     <div class='wrapper'>
       <div role='contentinfo'>
-        <header>
+        <header style={{background: item.color.css || 'white'}}>
+          <svg class='item-icon'>
+            <use
+              xlinkHref={getIcon(iconName || item.slug, enableDefaultIcon)}
+            />
+          </svg>
           <CloseButton />
-          <h3>{item.name}</h3>
-          <main>
-            <p>Foo</p>
-          </main>
-          <footer />
         </header>
+        <main>
+          <h3>{item.name}</h3>
+          <p>Foo</p>
+        </main>
       </div>
     </div>
   </div>

--- a/client/app/components/AccountItem.jsx
+++ b/client/app/components/AccountItem.jsx
@@ -5,7 +5,7 @@ import { translate } from '../plugins/preact-polyglot'
 
 const AccountItem = ({ title, subtitle, slug, iconName, backgroundCSS = 'white', enableDefaultIcon = false, router }) => (
   <Link class='item-wrapper' to={`${router.location.pathname}/${slug}`}>
-    <header style={{background: backgroundCSS}}>
+    <header class='item-header' style={{background: backgroundCSS}}>
       {iconName &&
         <svg class='item-icon'>
           <use xlinkHref={icon(iconName, enableDefaultIcon)} />

--- a/client/app/components/AccountItem.jsx
+++ b/client/app/components/AccountItem.jsx
@@ -17,9 +17,10 @@ const AccountItem = ({ title, subtitle, slug, iconName, backgroundCSS = 'white',
   </Link>
 )
 
+// Fallback to get the item icon and avoid error if not found
+// with a possible default icon
 const icon = (iconName, enableDefaultIcon) => {
   let icon = ''
-    // fallback to use a default icon if icon not found
   try {
     icon = require(`../assets/icons/${iconName}.svg`)
   } catch (e) {

--- a/client/app/components/AccountItem.jsx
+++ b/client/app/components/AccountItem.jsx
@@ -18,15 +18,13 @@ const AccountItem = ({ title, subtitle, slug, iconName, backgroundCSS = 'white',
 )
 
 const icon = (iconName, enableDefaultIcon) => {
-  let icon
+  let icon = ''
     // fallback to use a default icon if icon not found
   try {
     icon = require(`../assets/icons/${iconName}.svg`)
   } catch (e) {
     if (enableDefaultIcon) {
       icon = require('../assets/icons/default_myaccount.svg')
-    } else {
-      icon = ''
     }
   }
   return icon

--- a/client/app/components/UseCaseDialog.jsx
+++ b/client/app/components/UseCaseDialog.jsx
@@ -22,7 +22,7 @@ const getItemBackground = (item, context) => {
 }
 
 const UseCaseDialog = ({ t, item, context }) => (
-  <div role='dialog'>
+  <div role='dialog' class='use-case-dialog'>
     <div class='wrapper'>
       <div role='contentinfo'>
         <header style={{background: getItemBackground(item, context)}}

--- a/client/app/components/UseCaseDialog.jsx
+++ b/client/app/components/UseCaseDialog.jsx
@@ -8,12 +8,24 @@ const CloseButton = withRouter(({ router }) => (
   <button role='close' onClick={router.goBack}>Close</button>
 ))
 
+const getItemBackground = (item, context) => {
+  let background = 'rgb(0, 130, 230)'
+  if (item.figure && context) {
+    try {
+      let img = require(`../contexts/${context}/assets/img/${item.figure}`)
+      background = `center/100% url(${img})`
+    } catch (e) {
+      background = 'rgb(0, 130, 230)'
+    }
+  }
+  return background
+}
+
 const UseCaseDialog = ({ t, item, context }) => (
   <div role='dialog'>
     <div class='wrapper'>
       <div role='contentinfo'>
-        <header style={{background:
-          `center/100% url(${require(`../contexts/${context}/assets/img/${item.figure}`)})`}}
+        <header style={{background: getItemBackground(item, context)}}
         >
           <CloseButton />
         </header>

--- a/client/app/components/UseCaseDialog.jsx
+++ b/client/app/components/UseCaseDialog.jsx
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router'
 import AccountItem from './AccountItem'
 
 const CloseButton = withRouter(({ router }) => (
-  <button role='close' onClick={router.goBack}>Close</button>
+  <div class='close-button' role='close' onClick={router.goBack} />
 ))
 
 const getItemBackground = (item, context) => {

--- a/client/app/components/UseCaseDialog.jsx
+++ b/client/app/components/UseCaseDialog.jsx
@@ -26,7 +26,9 @@ const UseCaseDialog = ({ t, item, context }) => (
   <div role='dialog' class='use-case-dialog'>
     <div class='wrapper'>
       <div role='contentinfo'>
-        <header style={{background: getItemBackground(item, context)}}
+        <header
+          class='dialog-header'
+          style={{background: getItemBackground(item, context)}}
         >
           <CloseButton />
         </header>

--- a/client/app/components/UseCaseDialog.jsx
+++ b/client/app/components/UseCaseDialog.jsx
@@ -8,6 +8,7 @@ const CloseButton = withRouter(({ router }) => (
   <div class='close-button' role='close' onClick={router.goBack} />
 ))
 
+// Fallback to get the item background image and avoid error if not found
 const getItemBackground = (item, context) => {
   let background = 'rgb(0, 130, 230)'
   if (item.figure && context) {

--- a/client/app/components/UseCaseDialog.jsx
+++ b/client/app/components/UseCaseDialog.jsx
@@ -2,23 +2,37 @@
 import { h } from 'preact'
 import { translate } from '../plugins/preact-polyglot'
 import { withRouter } from 'react-router'
+import AccountItem from './AccountItem'
 
 const CloseButton = withRouter(({ router }) => (
   <button role='close' onClick={router.goBack}>Close</button>
 ))
 
-const UseCaseDialog = ({ t, item }) => (
+const UseCaseDialog = ({ t, item, context }) => (
   <div role='dialog'>
     <div class='wrapper'>
       <div role='contentinfo'>
-        <header>
+        <header style={{background:
+          `center/100% url(${require(`../contexts/${context}/assets/img/${item.figure}`)})`}}
+        >
           <CloseButton />
-          <h3>{item.slug}</h3>
-          <main>
-            <p>Foo</p>
-          </main>
-          <footer />
         </header>
+        <main>
+          <h3>{t(`use-case ${item.slug} title`)}</h3>
+          <p>{t(`use-case ${item.slug} description`)}</p>
+          <div class='accounts-list'>
+            {item.accounts.map(a =>
+              <AccountItem
+                title={a.name}
+                subtitle={t(a.category + ' category')}
+                iconName={a.slug}
+                slug={a.slug}
+                enableDefaultIcon
+                backgroundCSS={a.color.css}
+              />
+            )}
+          </div>
+        </main>
       </div>
     </div>
   </div>

--- a/client/app/components/UseCasesList.jsx
+++ b/client/app/components/UseCasesList.jsx
@@ -3,6 +3,19 @@ import { h } from 'preact'
 import { translate } from '../plugins/preact-polyglot'
 import UseCaseItem from './AccountItem'
 
+const getItemBackground = (item, context) => {
+  let background = 'rgb(0, 130, 230)'
+  if (item.figure && context) {
+    try {
+      let img = require(`../contexts/${context}/assets/img/${item.figure}`)
+      background = `center/100% url(${img})`
+    } catch (e) {
+      background = 'rgb(0, 130, 230)'
+    }
+  }
+  return background
+}
+
 const UseCasesList = ({ t, useCases, context }) => (
   <div class='use-cases-list'>
     {useCases.map(u =>
@@ -10,9 +23,7 @@ const UseCasesList = ({ t, useCases, context }) => (
         title={t(`use-case ${u.slug} title`)}
         slug={u.slug}
         enableDefaultIcon={false}
-        backgroundCSS={
-          `center/100% url(${require(`../contexts/${context}/assets/img/${u.figure}`)})`
-        }
+        backgroundCSS={getItemBackground(u, context)}
       />
     )}
   </div>

--- a/client/app/components/UseCasesList.jsx
+++ b/client/app/components/UseCasesList.jsx
@@ -3,6 +3,7 @@ import { h } from 'preact'
 import { translate } from '../plugins/preact-polyglot'
 import UseCaseItem from './AccountItem'
 
+// Fallback to get the item background image and avoid error if not found
 const getItemBackground = (item, context) => {
   let background = 'rgb(0, 130, 230)'
   if (item.figure && context) {

--- a/client/app/contexts/cozy/index.json
+++ b/client/app/contexts/cozy/index.json
@@ -1,7 +1,7 @@
 {
   "useCases":[{
     "slug": "phone-bills",
-    "konnectors": [{
+    "accounts": [{
       "slug": "virgin_mobile"
     }, {
       "slug": "sfr_mobile"

--- a/client/app/index.jsx
+++ b/client/app/index.jsx
@@ -31,7 +31,7 @@ const accountsByCategory = ({filter}) => {
     : unconnectedAccounts.filter(a => a.category === filter)
 }
 
-// complete a given use case with all related accounts object
+// To complete a given use case with all related accounts object
 const completeUseCase = (usecase) => {
   if (!usecase) return null
   if (usecase.accounts) {
@@ -86,6 +86,7 @@ render((
           component={(props) =>
             <AccountDialog
               item={accounts.find(a => a.slug === props.params.account)}
+              enableDefaultIcon
               {...props}
             />}
         />
@@ -100,6 +101,7 @@ render((
           component={(props) =>
             <AccountDialog
               item={accounts.find(u => u.slug === props.params.account)}
+              enableDefaultIcon
               {...props}
             />}
         />

--- a/client/app/index.jsx
+++ b/client/app/index.jsx
@@ -31,6 +31,21 @@ const accountsByCategory = ({filter}) => {
     : unconnectedAccounts.filter(a => a.category === filter)
 }
 
+// complete a given use case with all related accounts object
+const completeUseCase = (usecase) => {
+  if (!usecase) return null
+  if (usecase.accounts) {
+    const completed = Object.assign({}, usecase)
+    completed.accounts = []
+    let account
+    usecase.accounts.map(a => {
+      account = accounts.find(u => u.slug === a.slug)
+      if (account) completed.accounts.push(account)
+    })
+    return completed
+  }
+}
+
 render((
   <Router history={hashHistory}>
     <Route
@@ -50,7 +65,10 @@ render((
           path=':useCase'
           component={(props) =>
             <UseCaseDialog
-              item={useCases.find(u => u.slug === props.params.useCase)}
+              item={completeUseCase(
+                  useCases.find(u => u.slug === props.params.useCase)
+              )}
+              context={context}
               {...props}
             />}
         />

--- a/client/app/index.jsx
+++ b/client/app/index.jsx
@@ -50,7 +50,7 @@ render((
   <Router history={hashHistory}>
     <Route
       component={(props) =>
-        <App context={context} lang={lang} categories={categories}{...props}
+        <App context={context} lang={lang} categories={categories} {...props}
         />}
     >
       <Redirect from='/' to='/discovery' />
@@ -71,6 +71,24 @@ render((
               context={context}
               {...props}
             />}
+        />
+        <Route
+          path=':useCase/:account'
+          component={(props) =>
+            <div class='multi-dialogs-wrapper'>
+              <UseCaseDialog
+                item={completeUseCase(
+                    useCases.find(u => u.slug === props.params.useCase)
+                )}
+                context={context}
+                {...props}
+              />
+              <AccountDialog
+                item={accounts.find(a => a.slug === props.params.account)}
+                enableDefaultIcon
+                {...props}
+              />
+            </div>}
         />
       </Route>
       <Redirect from='/category' to='/category/all' />

--- a/client/app/styles/index.styl
+++ b/client/app/styles/index.styl
@@ -157,22 +157,24 @@ aside
 
     // specific to use case dialog
     &.use-case-dialog
-        [role=contentinfo] main
-            > h3
-                font-size       32px
-                margin          1em 0em .5em 1.5em
+        [role=contentinfo]
+            flex-basis          75rem
+            main
+                > h3
+                    font-size       32px
+                    margin          1em 0em .5em 1.5em
 
-            > p
-                margin-left     3em
-                margin-bottom   2em
-
-            .accounts-list
-                margin-bottom   5em
-                margin-left     .5em
-                justify-content center
+                > p
+                    margin-left     3em
+                    margin-bottom   2em
+                .accounts-list
+                    margin-bottom   5em
+                    margin-left     .5em
+                    justify-content center
 
     // specific to account dialog
     &.account-dialog
+        padding-top         .5em
         .dialog-header
             svg
                 height      6em

--- a/client/app/styles/index.styl
+++ b/client/app/styles/index.styl
@@ -83,7 +83,7 @@ aside
             box-shadow          0 4px 12px 0 rgba(0, 0, 0, 0.25)
             transform           scale(1.05)
             transition          .2s ease all
-        header
+        .item-header
             border-radius       4px 4px 0px 0px
             height              9em
             position            relative
@@ -144,7 +144,7 @@ aside
         flex-basis          80rem
         box-shadow          0 6px 18px 0 rgba(0, 0, 0, 0.22), 0 1px 3px 0 rgba(0, 0, 0, 0.16)
 
-        header
+        .dialog-header
             height                      10em
             overflow                    hidden
             border-top-left-radius      inherit
@@ -173,7 +173,7 @@ aside
 
     // specific to account dialog
     &.account-dialog
-        header
+        .dialog-header
             svg
                 height      6em
                 width       100%

--- a/client/app/styles/index.styl
+++ b/client/app/styles/index.styl
@@ -150,7 +150,7 @@ aside
             border-top-left-radius      inherit
             border-top-right-radius     inherit
 
-        main
+        > main
             width               90%
             margin              auto
 
@@ -159,7 +159,7 @@ aside
     &.use-case-dialog
         [role=contentinfo]
             flex-basis          75rem
-            main
+            > main
                 > h3
                     font-size       32px
                     margin          1em 0em .5em 1.5em

--- a/client/app/styles/index.styl
+++ b/client/app/styles/index.styl
@@ -103,6 +103,8 @@ aside
             margin              0em .5em
             color               $grey-06
 
+
+// Global styles for dialog
 [role=dialog]
     @extend $dialog
     background-color     rgba(78, 91, 105, 0.75)
@@ -140,6 +142,7 @@ aside
         flex-direction      column
         border              none
         flex-basis          80rem
+        box-shadow          0 6px 18px 0 rgba(0, 0, 0, 0.22), 0 1px 3px 0 rgba(0, 0, 0, 0.16)
 
         header
             height                      10em
@@ -151,6 +154,10 @@ aside
             width               90%
             margin              auto
 
+
+    // specific to use case dialog
+    &.use-case-dialog
+        [role=contentinfo] main
             > h3
                 font-size       32px
                 margin          1em 0em .5em 1.5em

--- a/client/app/styles/index.styl
+++ b/client/app/styles/index.styl
@@ -116,6 +116,25 @@ aside
         padding 3em 1em
         box-sizing border-box
 
+    .close-button
+        height                  3em
+        width                   3em
+        cursor                  pointer
+        position                absolute
+        right                   4em
+        top                     3.5em
+        &:after, &:before
+            position            absolute
+            content             ' '
+            height              3em
+            width               2px
+            background-color    white
+            margin              0em 1.5em
+        &:after
+            transform: rotate(-45deg);
+        &:before
+            transform: rotate(45deg);
+
     [role=contentinfo]
         overflow            initial
         flex-direction      column

--- a/client/app/styles/index.styl
+++ b/client/app/styles/index.styl
@@ -170,3 +170,11 @@ aside
                 margin-bottom   5em
                 margin-left     .5em
                 justify-content center
+
+    // specific to account dialog
+    &.account-dialog
+        header
+            svg
+                height      6em
+                width       100%
+                margin      2em 0em

--- a/client/app/styles/index.styl
+++ b/client/app/styles/index.styl
@@ -105,6 +105,7 @@ aside
 
 [role=dialog]
     @extend $dialog
+    background-color     rgba(78, 91, 105, 0.75)
 
     [role=separator]
         cursor pointer
@@ -116,5 +117,30 @@ aside
         box-sizing border-box
 
     [role=contentinfo]
-        overflow initial
-        flex-direction column
+        overflow            initial
+        flex-direction      column
+        border              none
+        flex-basis          80rem
+
+        header
+            height                      10em
+            overflow                    hidden
+            border-top-left-radius      inherit
+            border-top-right-radius     inherit
+
+        main
+            width               90%
+            margin              auto
+
+            > h3
+                font-size       32px
+                margin          1em 0em .5em 1.5em
+
+            > p
+                margin-left     3em
+                margin-bottom   2em
+
+            .accounts-list
+                margin-bottom   5em
+                margin-left     .5em
+                justify-content center

--- a/docs/client-side-use-cases-configuration.md
+++ b/docs/client-side-use-cases-configuration.md
@@ -16,9 +16,9 @@ This document describes the context of using _use-cases_ in MyAccounts app, how 
 What are use-cases?
 -------------------
 
-A **use-case** is a way to sort and filter konnectors by an arbitrary denominator (e.g. _all konnectors that concerns billing_). It allows a user to browse available konnectors in a different way than browsing by categories. The user can discover some konnectors by selecting first a _use-case_ (aka a scenario) that cover usages, and see what konnectors can be suggested.
+A **use-case** is a way to sort and filter accounts by an arbitrary denominator (e.g. _all accounts that concerns billing_). It allows a user to browse available accounts in a different way than browsing by categories. The user can discover some accounts by selecting first a _use-case_ (aka a scenario) that cover usages, and see what accounts can be suggested.
 
-_MyAccounts_ can provide many _use-cases_, that can be configured, which means that an hoster can offer a different way to discover available konnectors (aka present different _use-cases_).
+_MyAccounts_ can provide many _use-cases_, that can be configured, which means that an hoster can offer a different way to discover available accounts (aka present different _use-cases_).
 
 
 How to define a use-case?
@@ -31,7 +31,7 @@ The `context` value is the one that defines in which context _MyAccounts_ app ru
 Adding a _use-case_ simply mean adding a new object into the _use-cases_ array, that provides the following keys (see the _Architecture_ section below for a complete list and informations):
 
 - `slug`: `<String>` the slugname for the use-case
-- `konnectors`: `<Array[Obj]>` an array of objects defining the konnectors
+- `accounts`: `<Array[Obj]>` an array of objects defining the accounts
 - `figure`: `<String>` the picture file that illustrate the use-case
 - `color`: `<Color>` a color object that defines the color of the use-case
 - `default`: `<Bool>` a `true|false` value that defines this use-case as the default one
@@ -47,7 +47,7 @@ There's two kind of default values for a _use-case_:
 
 ### the `default` key
 
-it defines if this _use-case_ is the default one. When we access the _use-cases_ screen (`/discover` URI), it offers a list of _use-cases_ screen, each one redirecting to a _use-case_ view (or the konnector if the _use-case_ only contains one).
+it defines if this _use-case_ is the default one. When we access the _use-cases_ screen (`/discover` URI), it offers a list of _use-cases_ screen, each one redirecting to a _use-case_ view (or the account if the _use-case_ only contains one).
 
 Sometimes, we need to directly open a _use-case_ screen without passing by the `/discover` view (this is the case when user access to _MyAccounts_ from the onboarding). In this case, this is the default _use-case_ which is displayed.
 
@@ -55,9 +55,9 @@ Sometimes, we need to directly open a _use-case_ screen without passing by the `
 
 ### The _incentive_
 
-When displaying a _use-case_ screen, a konnector can be highlighted first to incitate the user to first configure this one. Into the `konnectors` array, the _Konnector Object_ can define a `default` key at `true` to declare it as the _incentive_ one.
+When displaying a _use-case_ screen, an account can be highlighted first to incitate the user to first configure this one. Into the `accounts` array, the _account Object_ can define a `default` key at `true` to declare it as the _incentive_ one.
 
-⚠️ as for the _use-cases_ array, if more than one konnector has a `default` key set to true, only the first one in the array is considered as the _incentive_ one.
+⚠️ as for the _use-cases_ array, if more than one account has a `default` key set to true, only the first one in the array is considered as the _incentive_ one.
 
 
 Localization
@@ -82,8 +82,8 @@ A manifest should have the following structure:
 {
   "use-cases": [{
     "slug": "the use-case slug",
-    "konnectors": [{
-      "slug": "konnector-to-add-slugname",
+    "accounts": [{
+      "slug": "account-to-add-slugname",
       "default": true,
       "important": true
     }],
@@ -97,9 +97,9 @@ A manifest should have the following structure:
 }
 ```
 
-The `important` key indicate if the _use-case_/_konnector_ is recommended or not.
+The `important` key indicate if the _use-case_/_account_ is recommended or not.
 
 The `default` key indicate if:
 
 - the _use-case_ is the one displayed by default (_onboarding_ view)
-- the _konnector_ into the list is the incentive one
+- the _account_ into the list is the incentive one


### PR DESCRIPTION
This PR:

* [x] Remove the reference to "konnector" in the use case index.json (with changes in doc) to use "account"
* [x] Add the content of the use case dialog with the related accounts list
* [x] Add sub-dialog for accounts in the use case dialog
* [x] Add styles for the use case dialog
* [x] Add generic close button (X)
* [x] Add some generic styles (also for the account dialog)