### PR TITLE
[fix] Trainline duplicate

### DIFF
--- a/server/konnectors/trainline.js
+++ b/server/konnectors/trainline.js
@@ -19,8 +19,7 @@ const logger = require('printit')({
 })
 
 module.exports = baseKonnector.createNew({
-  name: 'Trainline (Captain Train)',
-  slug: 'trainline',
+  name: 'Trainline',
   vendorLink: 'www.captaintrain.com',
 
   category: 'transport',


### PR DESCRIPTION
Fixed it the hard way, as the stack v2 gonna be there soon, and the actual code is a mess of untestable coffee callbacks.

So, thanks to God only Trainline was having issue during migration, not the two other connectors being migrated (Virgin Mobile and Voyages SNCF). The only difference spotted was that no slug was specified for those ones. So in the first place I remove the slug from trainline konnector. It worked. There was no more duplicate of trainline konnector, but in DB, there was always two connectors  trainline and trainline_(captain_train).

Finally, Changing the name from "Trainline (Captain Train)" to "Trainline" fixed the whole issue.