### PR TITLE
Malakoff Mederic connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The connectors marked with :x: are known as currently broken.
 | Free                    | PDF  | ZeHiro                                                | :white_check_mark:                                                                            |
 | Free Mobile             | PDF  | ZeHiro                                                | :white_check_mark:                                                                            |
 | Github                  | PDF  | doubleface                                            | :white_check_mark:                                                                            |
+| Malakoff Mederic        | PDF  | Gara64                                                | :white_check_mark:                                                                            |
 | Materiel.net            | PDF  | nicofrand                                             | :white_check_mark:                                                                            |
 | Numéricable             | PDF  | nicofrand                                             | :white_check_mark:                                                                            |
 | OVH CA                  | PDF  | Chocobozzz                                            | :x: ([needs an app token](https://github.com/cozy-labs/konnectors/issues/370))                |

--- a/client/app/locales/en.coffee
+++ b/client/app/locales/en.coffee
@@ -154,6 +154,7 @@ module.exports =
     'konnector customview orange_mobile': "To do that: <ol><li>use the 'connect' button to connect on your Orange Mobile account with your <b>mobile phone number</b>,</li><li>select 'every hour' as update schedule,</li><li>then click on 'Import and Save'.</li></ol>"
     'konnector description orange_vod': "Orange (France) invites you to download the film and video watching history of your LiveBox in your Cozy. Notice that this transmission can take up to a few weeks to start."
     'konnector customview orange_vod': "To do that: <ol><li>use the 'connect' button to connect on your Orange account with your <b>mobile phone number</b>,</li><li>select 'every hour' as update schedule,</li><li>then click on 'Import and Save'.</li></ol>"
+    'konnector description malakoff_mederic': "Import your Malakoff Mederic reimbursements in your Cozy."
 
     # Konnectors' notifications
     'notification import error': 'an error occurred during import of data'
@@ -170,6 +171,7 @@ module.exports =
     'notification rescuetime': "%{smart_count} new activity imported |||| %{smart_count} new activities imported"
     'notification birthdays creation': "%{smart_count} new birthday created |||| %{smart_count} new birthdays created"
     'notification ameli': "%{smart_count} new reimbursement imported |||| %{smart_count} new reimbursements imported"
+    'notification malakoff_mederic': "%{smart_count} new reimbursement imported |||| %{smart_count} new reimbursements imported"
     'notification podcast': "%{smart_count} new podcast imported |||| %{smart_count} new podcasts imported"
     'notification isen': "%{smart_count} new course material imported |||| %{smart_count} new course materials imported"
     'notification isen event changed': "Careful, the intervention %{description} will take place on %{newDate} instead of %{oldDate}"

--- a/client/app/locales/fr.coffee
+++ b/client/app/locales/fr.coffee
@@ -154,6 +154,7 @@ module.exports =
     'konnector customview orange_mobile': "Pour cela : <ol><li>connectez-vous à votre compte en ligne Orange via le bouton 'connect' puis indiquez votre <b>numéro de mobile</b> Orange et votre mot de passe Orange,</li><li>sélectionnez 'Toutes les heures' comme fréquence de mise à jour,</li><li>puis cliquez sur 'importer et sauvegarder'.</li></ol>"
     'konnector description orange_vod': "Orange vous propose de télécharger automatiquement l'historique des film et vidéo que vous avez regarder via la VoD ou votre LiveBox, dans votre Cozy. Attention, cette transmission expérimentale de données a un délais d'activation, qui peut être de quelques semaines."
     'konnector customview orange_vod': "Pour cela : <ol><li>connectez-vous à votre compte en ligne Orange via le bouton 'connect' puis indiquez votre <b>l'adresse email</b> de votre compte Orange et votre mot de passe Orange,</li><li>sélectionnez 'Toutes les semaines' comme fréquence de mise à jour,</li><li>puis cliquez sur 'importer et sauvegarder'.</li></ol>"
+    'konnector description malakoff_mederic': "Importez vos remboursements Malakoff Mederic dans votre Cozy."
 
     # Konnectors' notifications
     'notification import error': "une erreur est survenue pendant l'importation des données"
@@ -170,6 +171,7 @@ module.exports =
     'notification rescuetime': "%{smart_count} nouvelle activité importée |||| %{smart_count} nouvelles activités importées"
     'notification birthdays creation': "%{smart_count} nouvel anniversaire créé. |||| %{smart_count} nouveaux anniversaires créés."
     'notification ameli': "%{smart_count} nouveau remboursement importé |||| %{smart_count} nouveaux remboursement importés"
+    'notification malakoff_mederic': "%{smart_count} nouveau remboursement importé |||| %{smart_count} nouveaux remboursement importés"
     'notification podcast': "%{smart_count} nouveau podcast importé |||| %{smart_count} nouveaux podcasts importés"
     'notification isen': "%{smart_count} nouveau support de cours importé |||| %{smart_count} nouveaux supports de cours importés"
     'notification isen event changed': "Attention, l'intervention %{description} se déroulera le %{newDate} au lieu du %{oldDate}"

--- a/server/konnectors/malakoff_mederic.coffee
+++ b/server/konnectors/malakoff_mederic.coffee
@@ -168,7 +168,7 @@ module.exports = baseKonnector.createNew
           model: Bill
           dateDelta: 10
           amountDelta: 0.1
-          identifier = 'MALAKOFF MEDERIC'
+          identifier: 'MALAKOFF MEDERIC'
         }),
         buildNotification
     ]

--- a/server/konnectors/malakoff_mederic.coffee
+++ b/server/konnectors/malakoff_mederic.coffee
@@ -143,7 +143,7 @@ buildNotification = (requiredFields, healthBills, data, next) ->
 
 
 fileOptions =
-    vendor: 'malakoff mederic'
+    vendor: 'Malakoffmederic'
     dateFormat: 'YYYYMMDD'
 
 

--- a/server/konnectors/malakoff_mederic.coffee
+++ b/server/konnectors/malakoff_mederic.coffee
@@ -94,7 +94,7 @@ logIn = (requiredFields, billInfos, data, next) ->
                 # Get the reimbursements
                 request options, (err, res, body) ->
                     if err
-                        logger.error err
+                        log.error err
                         return next 'request error'
 
                     data.html = body
@@ -111,7 +111,7 @@ parsePage = (requiredFields, healthBills, data, next) ->
 
     $('.headerRemboursements').each ->
         amount = $(this).find('.montant').text()
-        amount = amount.replace(' €', '')
+        amount = amount.replace(' €', '').replace(',', '.')
         amount = parseFloat amount
 
         dateText = $(this).find('.dateEmission').text()
@@ -135,10 +135,9 @@ buildNotification = (requiredFields, healthBills, data, next) ->
     log.info "Import finished"
     notifContent = null
     if healthBills?.filtered?.length > 0
-        localizationKey = 'notification malakoff'
+        localizationKey = 'notification bills'
         options = smart_count: healthBills.filtered.length
         healthBills.notifContent = localization.t localizationKey, options
-
     next()
 
 

--- a/server/konnectors/malakoff_mederic.coffee
+++ b/server/konnectors/malakoff_mederic.coffee
@@ -1,0 +1,183 @@
+cozydb = require 'cozydb'
+request = require 'request'
+moment = require 'moment'
+cheerio = require 'cheerio'
+fs = require 'fs'
+async = require 'async'
+File = require '../models/file'
+Bill = require '../models/bill'
+baseKonnector = require '../lib/base_konnector'
+filterExisting = require '../lib/filter_existing'
+saveDataAndFile = require '../lib/save_data_and_file'
+linkBankOperation = require '../lib/link_bank_operation'
+
+localization = require '../lib/localization_manager'
+
+log = require('printit')
+    prefix: "Malakoff Mederic"
+    date: true
+
+domain = "https://extranet.malakoffmederic.com"
+
+# Procedure to login to Malakoff Mederic website.
+logIn = (requiredFields, billInfos, data, next) ->
+    options =
+        method: 'GET'
+        jar: true
+        url: "#{domain}/espaceClient/LogonAccess.do"
+
+    # Get the cookie
+    request options, (err, res, body) ->
+        if err
+            return next 'request error'
+
+        # This id is stored in the cookie and used to check the log in
+        httpSessionId = res.headers['set-cookie'][0]
+        httpSessionId = httpSessionId.split(';')[0]
+        httpSessionId = httpSessionId.split('=')[1]
+
+        engineUrl = "https://extranet.malakoffmederic.com/dwr/engine.js"
+        genOptions =
+            url: engineUrl
+            jar: true
+
+        # Request a js page to extract a generated session id: because why not
+        request genOptions, (err, res, body) ->
+            if err
+                return next 'request error'
+
+            regexp = /dwr.engine._origScriptSessionId = "([A-Z0-9]+)"/g
+            matches = body.match regexp
+            id = matches[0].split('"')[1]
+            # The client must generate 3 random digits
+            scriptSessionId = id + Math.floor(Math.random() * 1000)
+
+            path = "/dwr/call/plaincall/InternauteValidator.checkConnexion.dwr"
+            submitUrl = "#{domain}#{path}"
+            checkOption =
+                method: 'POST'
+                jar: true
+                url: submitUrl
+                headers:
+                    'Content-Type': 'text/plain'
+                body:
+                    "callCount=1\n\
+                    page=/espaceClient/LogonAccess.do\n\
+                    httpSessionId=#{httpSessionId}\n\
+                    scriptSessionId=#{scriptSessionId}\n\
+                    c0-scriptName=InternauteValidator\n\
+                    c0-methodName=checkConnexion\n\
+                    c0-id=0\n\
+                    c0-param0=boolean:false\n\
+                    c0-param1=string:#{requiredFields.login}\n\
+                    c0-param2=string:#{requiredFields.password}\n\
+                    batchId=0\n"
+
+            # Log in
+            request checkOption, (err, res, body) ->
+                if err or res.statusCode >= 400
+                    log.error err
+                    return next 'request error'
+                # The body should not contain LOGON_KO
+                if body.indexOf('LOGON_KO') > -1
+                    log.error 'Authentication error'
+                    return next 'bad credentials'
+
+                log.info 'Logged in'
+
+                path = "/espaceClient/sante/tbs/redirectionAction.do"
+                reimbursementUrl = "#{domain}#{path}"
+                options =
+                    method: 'GET'
+                    url: reimbursementUrl
+                    jar: true
+
+                # Get the reimbursements
+                request options, (err, res, body) ->
+                    if err
+                        logger.error err
+                        return next 'request error'
+
+                    data.html = body
+                    next()
+
+
+# Parse the fetched page to extract bill data.
+parsePage = (requiredFields, healthBills, data, next) ->
+
+    healthBills.fetched = []
+    return next() if not data.html?
+
+    $ = cheerio.load data.html
+
+    $('.headerRemboursements').each ->
+        amount = $(this).find('.montant').text()
+        amount = amount.replace(' €', '')
+        amount = parseFloat amount
+
+        dateText = $(this).find('.dateEmission').text()
+        date = dateText.split('Emis le ')[1].split('aux')[0]
+        console.log 'date : ' + date
+
+        pdfUrl = $(this).find('#tbsRembExportPdf').attr('href')
+        pdfUrl = "#{domain}#{pdfUrl}"
+
+        bill =
+            amount: amount
+            type: 'health'
+            date: moment date, 'DD/MM/YYYY'
+            vendor: 'Malakoff Mederic'
+            pdfurl: pdfUrl
+
+        healthBills.fetched.push bill if bill.amount?
+    next()
+
+
+
+buildNotification = (requiredFields, healthBills, data, next) ->
+    log.info "Import finished"
+    notifContent = null
+    if healthBills?.filtered?.length > 0
+        localizationKey = 'notification malakoff'
+        options = smart_count: healthBills.filtered.length
+        healthBills.notifContent = localization.t localizationKey, options
+
+    next()
+
+customLinkBankOperation = (requiredFields, healthBills, data, next) ->
+    identifier = 'MALAKOFF MEDERIC'
+    bankIdentifier = requiredFields.bank_identifier
+    identifier = bankIdentifier if bankIdentifier? and bankIdentifier isnt ""
+
+    linkBankOperation(
+        log: log
+        model:  Bill
+        identifier: identifier
+        dateDelta: 10
+        amountDelta: 0.1
+    )(requiredFields, healthBills, data, next)
+
+fileOptions =
+    vendor: 'malakoff mederic'
+    dateFormat: 'YYYYMMDD'
+
+
+module.exports = baseKonnector.createNew
+    name: "Malakoff Mederic"
+    vendorLink: "http://www.malakoffmederic.com/index.jsp"
+
+    fields:
+        login: "text"
+        password: "password"
+        folderPath: "folder"
+
+    models: [Bill]
+
+    fetchOperations: [
+        logIn,
+        parsePage,
+        filterExisting(log, Bill),
+        saveDataAndFile(log, Bill, fileOptions, ['health', 'bill']),
+        customLinkBankOperation,
+        buildNotification
+    ]


### PR DESCRIPTION
This PR adds the Malakoff Mederic connector. It is a health insurance, so it imports health reimbursements, just like the Ameli connector.
The login process is a bit ugly, mainly because the Malakoff website requires to parse a generated session id in a js page.
I tested on my own account (except for the bank link), and it seems fine.