### PR TITLE
[fix] On deleting a config for a given konnector, reset the poller.

### DIFF
--- a/server/controllers/konnectors.coffee
+++ b/server/controllers/konnectors.coffee
@@ -60,6 +60,12 @@ module.exports =
             lastSuccess: null
             accounts: []
             password: null
+            importInterval: 'none'
+
+        ## Remove the konnector from the poller
+        poller = require "../lib/poller"
+        log.info "Removing konnector #{req.konnector.slug} from the poller"
+        poller.remove req.konnector
 
         req.konnector.updateAttributes data, (err, konnector) ->
             return next err if err

--- a/server/lib/poller.coffee
+++ b/server/lib/poller.coffee
@@ -145,15 +145,18 @@ class KonnectorPoller
         @createTimeout konnector, nextUpdate
 
 
+    remove: (konnector) ->
+        if @timeouts[konnector.slug]?
+            clearTimeout @timeouts[konnector.slug]
+            delete @timeouts[konnector.slug]
+
     # Update import timeout and nextUpdates for a given konnector.
     # This function should be called after a modification or a creation
     # of a connector.
     add: (startDate, konnector, callback=null) ->
 
         # If there is already a timeout for this konnector, destroy it.
-        if @timeouts[konnector.slug]?
-            clearTimeout @timeouts[konnector.slug]
-            delete @timeouts[konnector.slug]
+        @remove konnector
 
         if konnector.importInterval isnt 'none'
             if konnector.shallRaiseEncryptedFieldsError()


### PR DESCRIPTION
Fixes #677