### PR TITLE
Add update route on konnector

### DIFF
--- a/client/app/components/AccountConfigForm.jsx
+++ b/client/app/components/AccountConfigForm.jsx
@@ -14,7 +14,7 @@ const folderLink = (path, folders) => {
   return `/apps/files/#folders/${folder.id}`
 }
 
-const AccountConfigForm = ({ t, customView, connectUrl, fields, dirty, error, submit, submitting }) => (
+const AccountConfigForm = ({ t, customView, fields, dirty, error, submit, submitting }) => (
   <div class={'account-form' + (error ? ' error' : '')}>
     {fields.folderPath &&
       <div>
@@ -48,7 +48,6 @@ const AccountConfigForm = ({ t, customView, connectUrl, fields, dirty, error, su
     <AccountLoginForm
       t={t}
       customView={customView}
-      connectUrl={connectUrl}
       fields={fields}
     />
     {error === 'bad credentials' &&

--- a/client/app/components/AccountConnection.jsx
+++ b/client/app/components/AccountConnection.jsx
@@ -6,7 +6,7 @@ import AccountLoginForm from './AccountLoginForm'
 import DataItem from './DataItem'
 import ReactMarkdown from 'react-markdown'
 
-const AccountConnection = ({ t, connector, connectUrl, fields, dirty, error, submit, submitting }) => {
+const AccountConnection = ({ t, connector, fields, dirty, error, submit, submitting }) => {
   const { name, customView, description } = connector
   return (
     <div class='account-connection'>
@@ -37,10 +37,8 @@ const AccountConnection = ({ t, connector, connectUrl, fields, dirty, error, sub
           <AccountLoginForm
             t={t}
             customView={customView}
-            connectUrl={connectUrl}
             fields={fields}
           />
-          {!connectUrl &&
             <div class='account-form-controls'>
               <button
                 disabled={!dirty}
@@ -53,7 +51,6 @@ const AccountConnection = ({ t, connector, connectUrl, fields, dirty, error, sub
                 <p class='errors'>{t('my_accounts account config bad credentials')}</p>
               }
             </div>
-          }
         </div>
       </div>
     </div>

--- a/client/app/components/AccountConnection.jsx
+++ b/client/app/components/AccountConnection.jsx
@@ -39,18 +39,18 @@ const AccountConnection = ({ t, connector, fields, dirty, error, submit, submitt
             customView={customView}
             fields={fields}
           />
-            <div class='account-form-controls'>
-              <button
-                disabled={!dirty}
-                aria-busy={submitting ? 'true' : 'false'}
-                onClick={submit}
-              >
-                {t('my_accounts account config button')}
-              </button>
-              {error === 'bad credentials' &&
-                <p class='errors'>{t('my_accounts account config bad credentials')}</p>
-              }
-            </div>
+          <div class='account-form-controls'>
+            <button
+              disabled={!dirty}
+              aria-busy={submitting ? 'true' : 'false'}
+              onClick={submit}
+            >
+              {t('my_accounts account config button')}
+            </button>
+            {error === 'bad credentials' &&
+              <p class='errors'>{t('my_accounts account config bad credentials')}</p>
+            }
+          </div>
         </div>
       </div>
     </div>

--- a/client/app/components/AccountConnection.jsx
+++ b/client/app/components/AccountConnection.jsx
@@ -8,6 +8,8 @@ import ReactMarkdown from 'react-markdown'
 
 const AccountConnection = ({ t, connector, fields, dirty, error, submit, submitting }) => {
   const { name, customView, description } = connector
+  // If there is no field displayed, the form is dirty by default.
+  dirty = dirty || Object.values(fields).every(field => field.type === 'hidden' || field.advanced)
   return (
     <div class='account-connection'>
       <div class='account-description'>

--- a/client/app/components/AccountLoginForm.jsx
+++ b/client/app/components/AccountLoginForm.jsx
@@ -3,18 +3,13 @@ import { h } from 'preact'
 
 import Field, { PasswordField, DropdownField } from './Field'
 
-const AccountLoginForm = ({ t, customView, connectUrl, fields }) => (
+const AccountLoginForm = ({ t, customView, fields }) => (
   <div class='account-form-login'>
     {customView &&
       <div class='coz-custom-view'
         dangerouslySetInnerHTML={{
           __html: customView.replace(/<%t (.*) %>/gi, (match, $1) => t($1))
         }} />
-    }
-    {connectUrl &&
-      <div class='coz-connect-url'>
-        <a href={connectUrl} role='button'>{t('oauth connect')}</a>
-      </div>
     }
     {Object.keys(fields)
       .filter(name => !fields[name].advanced)

--- a/client/app/containers/ConnectorManagement.jsx
+++ b/client/app/containers/ConnectorManagement.jsx
@@ -112,7 +112,7 @@ export default class ConnectorManagement extends Component {
 
   connectAccount (values) {
     if (this.state.connector.connectUrl) {
-      return this.connectAccountOAuth(values);
+      return this.connectAccountOAuth(values)
     }
 
     const id = this.state.connector.id
@@ -141,7 +141,7 @@ export default class ConnectorManagement extends Component {
   connectAccountOAuth (values) {
     return this._updateAccount(0, values)
       .then(() => {
-          window.location = prepareConnectURL(this.state.connector)
+        window.location = prepareConnectURL(this.state.connector)
       })
   }
 
@@ -149,10 +149,9 @@ export default class ConnectorManagement extends Component {
     const { t } = this.context
     this._updateAccount(idx, values)
       .then(() => {
-          Notifier.info(t('my_accounts account config success'))
+        Notifier.info(t('my_accounts account config success'))
       })
   }
-
 
   _updateAccount (idx, values) {
     const id = this.state.connector.id
@@ -169,7 +168,6 @@ export default class ConnectorManagement extends Component {
         return Promise.reject(error)
       })
   }
-
 
   synchronize () {
     const id = this.state.connector.id

--- a/client/app/containers/ConnectorManagement.jsx
+++ b/client/app/containers/ConnectorManagement.jsx
@@ -74,7 +74,6 @@ export default class ConnectorManagement extends Component {
           ? <AccountManagement
             name={name}
             customView={customView}
-            connectUrl={prepareConnectURL(this.state.connector)}
             lastImport={lastImport}
             accounts={accounts}
             values={accounts[selectedAccount] || {}}
@@ -112,6 +111,10 @@ export default class ConnectorManagement extends Component {
   }
 
   connectAccount (values) {
+    if (this.state.connector.connectUrl) {
+      return this.connectAccountOAuth(values);
+    }
+
     const id = this.state.connector.id
     const { t } = this.context
     this.setState({ submitting: true })
@@ -135,24 +138,38 @@ export default class ConnectorManagement extends Component {
       })
   }
 
+  connectAccountOAuth (values) {
+    return this._updateAccount(0, values)
+      .then(() => {
+          window.location = prepareConnectURL(this.state.connector)
+      })
+  }
+
   updateAccount (idx, values) {
+    const { t } = this.context
+    this._updateAccount(idx, values)
+      .then(() => {
+          Notifier.info(t('my_accounts account config success'))
+      })
+  }
+
+
+  _updateAccount (idx, values) {
     const id = this.state.connector.id
     const { t } = this.context
     this.setState({ submitting: true })
-    this.store.updateAccount(id, idx, values)
+    return this.store.updateAccount(id, idx, values)
       .then(fetchedConnector => {
         this.setState({ submitting: false })
-        if (fetchedConnector.importErrorMessage) {
-          this.setState({ error: fetchedConnector.importErrorMessage })
-        } else {
-          Notifier.info(t('my_accounts account config success'))
-        }
+        return fetchedConnector
       })
       .catch(error => { // eslint-disable-line
         this.setState({ submitting: false })
         Notifier.error(t('my_accounts account config error'))
+        return Promise.reject(error)
       })
   }
+
 
   synchronize () {
     const id = this.state.connector.id

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
     "normalize.css": "5.0.0",
     "preact": "^7.1.0",
     "preact-compat": "^3.9.2",
+    "react-markdown": "^2.4.4",
     "react-router": "^3.0.0",
     "timeago-react": "^1.0.7"
   },

--- a/server/controllers/konnectors.coffee
+++ b/server/controllers/konnectors.coffee
@@ -18,34 +18,7 @@ module.exports =
             else if not konnector?
                 res.sendStatus 404
             else
-
-                konnector.injectEncryptedFields()
-                konnector.appendConfigData()
-                konnector.checkProperties()
-
-                if konnector.shallRaiseEncryptedFieldsError()
-                    konnector.importErrorMessage = 'encrypted fields'
-                else
-                    konnector.injectEncryptedFields()
-
-                # Add customView field
-                konnectorModule = require(
-                    path.join(
-                        '..',
-                        'konnectors',
-                        konnector.slug
-                    )
-                )
-                if konnectorModule.default?
-                    konnectorModule = konnectorModule.default
-
-                if konnectorModule.customView?
-                    konnector.customView = konnectorModule.customView
-
-                if konnectorModule.connectUrl?
-                    konnector.connectUrl = konnectorModule.connectUrl
-
-                req.konnector = konnector
+                req.konnector = decorateKonnector konnector
                 next()
 
 
@@ -76,6 +49,24 @@ module.exports =
             return next err if err
 
             res.status(204).send konnector
+
+    update: (req, res, next) ->
+        # Don't update connector if an import is already running.
+        if req.konnector.isImporting
+            res.send 400, message: 'konnector is importing'
+
+        else
+            # Extract date information. # Why ?
+            if req.body.date?
+                if req.body.date isnt ''
+                    date = req.body.date
+                delete req.body.date
+
+            req.konnector.updateFieldValues req.body, (err, updated) ->
+                if err?
+                    next err
+                else
+                    res.status(200).send decorateKonnector updated
 
 
     # Start import for a given konnector. Change state of the konnector during
@@ -155,3 +146,35 @@ module.exports =
 </body>
 </html>
 """
+
+
+decorateKonnector = (konnector) ->
+    konnector.injectEncryptedFields()
+    konnector.appendConfigData()
+    konnector.checkProperties()
+
+    if konnector.shallRaiseEncryptedFieldsError()
+        konnector.importErrorMessage = 'encrypted fields'
+    else
+        konnector.injectEncryptedFields()
+
+    # Add customView field
+    konnectorModule = require(
+        path.join(
+            '..',
+            'konnectors',
+            konnector.slug
+        )
+    )
+    if konnectorModule.default?
+        konnectorModule = konnectorModule.default
+
+    if konnectorModule.customView?
+        konnector.customView = konnectorModule.customView
+
+    if konnectorModule.connectUrl?
+        konnector.connectUrl = konnectorModule.connectUrl
+
+    return konnector
+
+

--- a/server/controllers/konnectors.coffee
+++ b/server/controllers/konnectors.coffee
@@ -121,6 +121,13 @@ module.exports =
         req.konnector.updateFieldValues { accounts: accounts }, (err) ->
             return next err if err
 
+            req.konnector.import (err, notifContent) ->
+                if err?
+                    log.error err
+                else
+                    handleNotification req.konnector, notifContent
+
+
             res.status(200).send """<!DOCTYPE html>
 <html>
 <head>
@@ -129,18 +136,7 @@ module.exports =
 <body>
     <script type="text/javascript">
         window.onload = function() {
-            //refreshParent;
-            if(window.opener){
-              window.opener.location.reload();
-              setTimeout(function() {
-                  window.close();
-              }, 500);
-            }
-            else {
-              window.location.href =
-                  "../../../#/category/#{req.konnector.category}/" +
-                        "#{req.konnector.slug}"
-            }
+            window.location.href = "../../../#/connected"
         };
     </script>
 </body>
@@ -176,5 +172,3 @@ decorateKonnector = (konnector) ->
         konnector.connectUrl = konnectorModule.connectUrl
 
     return konnector
-
-

--- a/server/controllers/routes.coffee
+++ b/server/controllers/routes.coffee
@@ -13,8 +13,11 @@ module.exports =
 
     'konnectors/:konnectorId':
         get: konnectors.show
-        put: konnectors.import
+        put: konnectors.update
         delete: konnectors.remove
+
+    'konnectors/:konnectorId/import':
+        post: konnectors.import
 
     'konnectors/:konnectorId/:accountId/redirect':
         get: konnectors.redirect

--- a/server/konnectors/facebook_events.js
+++ b/server/konnectors/facebook_events.js
@@ -26,8 +26,6 @@ const oAuthProxyUrl = getOAuthProxyUrl()
 const connector = module.exports = baseKonnector.createNew({
   name: 'Facebook Events',
   slug: 'facebook_events',
-  customView: `<a href=${oAuthProxyUrl} target="_blank" role="button">` +
-    `<%t konnector facebook_events connect %></a>`,
 
   category: 'social',
   color: {
@@ -35,13 +33,13 @@ const connector = module.exports = baseKonnector.createNew({
     css: '#395185'
   },
 
+  connectUrl: getOAuthProxyUrl(),
   fields: {
     accessToken: {
-      type: 'text'
+      type: 'hidden'
     },
     calendar: {
-      type: 'text',
-      advanced: true
+      type: 'text'
     }
   },
 
@@ -104,30 +102,17 @@ function saveTokenInKonnector (requiredFields, entries, data, callback) {
   const Konnector = require('../models/konnector')
   /* eslint-enable global-require */
   // TODO: should work:
-  // Konnector.get(connector.slug, function(err, konnector) {
-  Konnector.all((err, konnectors) => {
+  Konnector.get(connector.slug, (err, konnector) => {
     if (err) {
       connector.logger.error(`Can't fetch konnector instances: ${err.msg}`)
-      return callback(err)
-    }
-    let konnector = null
-    try {
-      konnector = konnectors.filter(k => k.slug === connector.slug)[0]
-
-      // Find which account we are using now.
-      const currentAccount = konnector.accounts.filter(account =>
-        account.accessToken === requiredFields.accessToken)[0]
-
-      currentAccount.accessToken = data.accessToken
-    } catch (e) {
-      connector.logger.error("Can't fetch konnector instances")
-      return callback(e)
+      return callback('internal error')
     }
 
-    return konnector.updateAttributes({ accounts: konnector.accounts },
-      callback)
-  })
+    requiredFields.accessToken = data.accessToken;
+    konnector.updateFieldValues({ accounts: [requiredFields] }, callback);
+  });
 }
+
 
 function downloadData (requiredFields, entries, data, next) {
   connector.logger.info('Downloading events data from Facebook...')

--- a/server/konnectors/facebook_events.js
+++ b/server/konnectors/facebook_events.js
@@ -17,7 +17,6 @@ const appSecret = 'a04e8cf918a382ea0b19cf1b6fbc2506'
 
 const scope = 'user_events'
 
-const oAuthProxyUrl = getOAuthProxyUrl()
 
 /*
  * The goal of this connector is to fetch event from facebook and store them
@@ -108,11 +107,10 @@ function saveTokenInKonnector (requiredFields, entries, data, callback) {
       return callback('internal error')
     }
 
-    requiredFields.accessToken = data.accessToken;
-    konnector.updateFieldValues({ accounts: [requiredFields] }, callback);
-  });
+    requiredFields.accessToken = data.accessToken
+    konnector.updateFieldValues({ accounts: [requiredFields] }, callback)
+  })
 }
-
 
 function downloadData (requiredFields, entries, data, next) {
   connector.logger.info('Downloading events data from Facebook...')


### PR DESCRIPTION
This is a preliminar work to integrate some modification on official Orange Mobile konnector, in the scope of the MesInfos pilote. ping @poupotte 

* Add update route on konnector, 
* in Oauth connectors, save account data before redirect to authent
* automatically import on redirect
* redirect to the connected page.
* update Facebook konnector
* fir #420 in Facebook konnector.

* Could be done : there isn't "everything fine" message with OAuth connector, but just a redirection to connected page: is there a quit fix to improve this ?



